### PR TITLE
stop running triggers if order were shipped without payment

### DIFF
--- a/src/triggers/tasks.py
+++ b/src/triggers/tasks.py
@@ -16,7 +16,7 @@ def run_started_purchase_trigger(order_id):
 
 @celery.task
 def check_for_started_purchase_triggers():
-    for order in Order.objects.filter(paid__isnull=True, created__gte=timezone.now() - timedelta(days=3)).iterator():
+    for order in Order.objects.filter(paid__isnull=True, shipped__isnull=True, created__gte=timezone.now() - timedelta(days=3)).iterator():
         run_started_purchase_trigger.delay(order.pk)
 
 

--- a/src/triggers/tests/started_purchase_trigger/tests_started_purchase_trigger_tasks.py
+++ b/src/triggers/tests/started_purchase_trigger/tests_started_purchase_trigger_tasks.py
@@ -40,6 +40,14 @@ def test_not_running_trigger_for_paid_orders(order, run_trigger):
     run_trigger.assert_not_called()
 
 
+def test_not_running_trigger_for_shipped_orders(order, run_trigger):
+    order.ship_without_payment()
+
+    tasks.check_for_started_purchase_triggers()
+
+    run_trigger.assert_not_called()
+
+
 def test_not_running_trigger_for_old_orders(order, run_trigger, freezer):
     freezer.move_to('2038-12-01 15:30')  # far in the future
 


### PR DESCRIPTION
@f213 в благодарность 🙏 за крутые курсы, прими в дар данный PR  :)

https://github.com/tough-dev-school/education-backend/issues/745

У нас появилась [возможность допускать](https://github.com/tough-dev-school/education-backend/blob/master/src/orders/admin/orders/admin.py#L44) учеников до занятий без оплаты. Такие заказы не считаются оплаченными, а значит на них отрабатывают все триггерные письма, к примеру [это](https://github.com/tough-dev-school/education-backend/blob/master/src/triggers/started_purchase.py#L8).

Надо исключить выполненные заказы (shipped__isnull=False) из триггерных расылок.