### PR TITLE
Diploma Generators: fix for possible or suppressed exceptions due not existed templates

### DIFF
--- a/src/diplomas/models.py
+++ b/src/diplomas/models.py
@@ -1,5 +1,7 @@
 import shortuuid
+from django.apps import apps
 from django.conf import settings
+from django.db.models import Exists, OuterRef
 from django.utils.translation import gettext_lazy as _
 from urllib.parse import urljoin
 
@@ -19,6 +21,19 @@ class DiplomaQuerySet(models.QuerySet):
 
     def for_user(self, user):
         return self.filter(study__student=user)
+
+    def filter_with_template(self) -> 'DiplomaQuerySet':
+        DiplomaTemplate = apps.get_model('diplomas.DiplomaTemplate')
+
+        return self.alias(
+            is_template_exists=Exists(
+                DiplomaTemplate.objects.filter(
+                    course=OuterRef('study__course'),
+                    language=OuterRef('language'),
+                    homework_accepted=OuterRef('study__homework_accepted'),
+                ),
+            ),
+        ).filter(is_template_exists=True)
 
 
 DiplomaManager = models.Manager.from_queryset(DiplomaQuerySet)

--- a/src/diplomas/models.py
+++ b/src/diplomas/models.py
@@ -26,14 +26,14 @@ class DiplomaQuerySet(models.QuerySet):
         DiplomaTemplate = apps.get_model('diplomas.DiplomaTemplate')
 
         return self.alias(
-            is_template_exists=Exists(
+            template_exists=Exists(
                 DiplomaTemplate.objects.filter(
                     course=OuterRef('study__course'),
                     language=OuterRef('language'),
                     homework_accepted=OuterRef('study__homework_accepted'),
                 ),
             ),
-        ).filter(is_template_exists=True)
+        ).filter(template_exists=True)
 
 
 DiplomaManager = models.Manager.from_queryset(DiplomaQuerySet)

--- a/src/diplomas/services/diploma_regenerator.py
+++ b/src/diplomas/services/diploma_regenerator.py
@@ -42,7 +42,7 @@ class DiplomaRegenerator:
     def diplomas(self) -> QuerySet[Diploma]:
         return (
             Diploma.objects.filter(study__student=self.student)
-            .filter_with_template()  # we have manually generated diplomas
+            .filter_with_template()  # some diplomas have no template, can't regenerate them
             .select_related('study')
         )
 

--- a/src/diplomas/tests/api/conftest.py
+++ b/src/diplomas/tests/api/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+from diplomas.models import Languages
+
 pytestmark = [pytest.mark.django_db]
 
 
@@ -15,4 +17,4 @@ def api(api):
 
 @pytest.fixture
 def diploma(factory):
-    return factory.diploma(language='EN')
+    return factory.diploma(language=Languages.EN)

--- a/src/diplomas/tests/api/tests_diploma_create.py
+++ b/src/diplomas/tests/api/tests_diploma_create.py
@@ -1,6 +1,6 @@
 import pytest
 
-from diplomas.models import Diploma
+from diplomas.models import Diploma, Languages
 
 pytestmark = [pytest.mark.django_db]
 
@@ -44,7 +44,7 @@ def test_uploading(api, payload, course, student):
 
     assert created.study.course == course
     assert created.study.student == student
-    assert created.language == 'RU'
+    assert created.language == Languages.RU
 
     assert '-4' in created.image.path
     assert created.image.path.endswith('.gif')

--- a/src/diplomas/tests/api/tests_diploma_retrieve.py
+++ b/src/diplomas/tests/api/tests_diploma_retrieve.py
@@ -1,11 +1,13 @@
 import pytest
 
+from diplomas.models import Languages
+
 pytestmark = [pytest.mark.django_db]
 
 
 @pytest.fixture
 def diploma_with_another_lang(mixer, diploma):
-    return mixer.blend('diplomas.Diploma', study=diploma.study, language='RU')
+    return mixer.blend('diplomas.Diploma', study=diploma.study, language=Languages.RU)
 
 
 def test(anon, diploma):

--- a/src/diplomas/tests/conftest.py
+++ b/src/diplomas/tests/conftest.py
@@ -1,7 +1,9 @@
 import pytest
 from functools import partial
 
+from diplomas.models import Languages
 from diplomas.services import DiplomaGenerator
+from users.models import User
 
 
 @pytest.fixture(autouse=True)
@@ -12,7 +14,7 @@ def _set_diploma_generator_url(settings):
 
 @pytest.fixture
 def student(mixer):
-    return mixer.blend('users.User', first_name='Овир', last_name='Кривомазов', gender='male')
+    return mixer.blend('users.User', first_name='Овир', last_name='Кривомазов', gender=User.GENDERS.MALE)
 
 
 @pytest.fixture
@@ -27,7 +29,12 @@ def order(factory, course, student):
 
 @pytest.fixture(autouse=True)
 def template(mixer, course):
-    return mixer.blend('diplomas.DiplomaTemplate', slug='test-template', course=course, language='RU', homework_accepted=False)
+    return mixer.blend(
+        'diplomas.DiplomaTemplate',
+        slug='test-template', course=course,
+        language=Languages.RU,
+        homework_accepted=False,
+    )
 
 
 @pytest.fixture

--- a/src/diplomas/tests/conftest.py
+++ b/src/diplomas/tests/conftest.py
@@ -27,7 +27,7 @@ def order(factory, course, student):
 
 @pytest.fixture(autouse=True)
 def template(mixer, course):
-    return mixer.blend('diplomas.DiplomaTemplate', slug='test-template', course=course, language='ru', homework_accepted=False)
+    return mixer.blend('diplomas.DiplomaTemplate', slug='test-template', course=course, language='RU', homework_accepted=False)
 
 
 @pytest.fixture

--- a/src/diplomas/tests/diploma_generator/tests_diploma_generator_functional.py
+++ b/src/diplomas/tests/diploma_generator/tests_diploma_generator_functional.py
@@ -14,7 +14,7 @@ def _mock_response(httpx_mock):
 
 
 def test_service(generator, student, course):
-    generator = generator(language='ru')
+    generator = generator(language='RU')
 
     diploma = generator()
 
@@ -24,7 +24,7 @@ def test_service(generator, student, course):
 
 
 def test_diploma_is_regenrated_when_it_already_exists(generator, student, course):
-    generator = generator(language='ru')
+    generator = generator(language='RU')
 
     first_diploma = generator()
     second_diploma = generator()
@@ -36,7 +36,7 @@ def test_diploma_is_regenrated_when_it_already_exists(generator, student, course
 
 
 def test_task(student, course):
-    generate_diploma.delay(student_id=student.id, course_id=course.id, language='ru')
+    generate_diploma.delay(student_id=student.id, course_id=course.id, language='RU')
 
     diploma = Diploma.objects.get(study__student=student, study__course=course)
 

--- a/src/diplomas/tests/diploma_generator/tests_diploma_generator_functional.py
+++ b/src/diplomas/tests/diploma_generator/tests_diploma_generator_functional.py
@@ -23,7 +23,7 @@ def test_service(generator, student, course):
     assert diploma.study.course == course
 
 
-def test_diploma_is_regenrated_when_it_already_exists(generator, student, course):
+def test_diploma_is_regenerated_when_it_already_exists(generator, student, course):
     generator = generator(language='RU')
 
     first_diploma = generator()

--- a/src/diplomas/tests/diploma_generator/tests_diploma_generator_retry.py
+++ b/src/diplomas/tests/diploma_generator/tests_diploma_generator_retry.py
@@ -35,7 +35,7 @@ def _reset_runs_count():
 
 @pytest.fixture
 def generator(generator):
-    return generator(language='ru')
+    return generator(language='RU')
 
 
 def test_ok(generator, httpx_mock):

--- a/src/diplomas/tests/diploma_generator/tests_diploma_generator_unit.py
+++ b/src/diplomas/tests/diploma_generator/tests_diploma_generator_unit.py
@@ -8,7 +8,7 @@ pytestmark = [
 
 
 def test_study_object(generator, order):
-    generator = generator(language='ru')
+    generator = generator(language='RU')
 
     assert generator.study == order.study, 'study object is returned'
 
@@ -20,7 +20,7 @@ def test_study_object(generator, order):
     ('male', 'm'),
 ])
 def test_sex(generator, gender, expected):
-    generator = generator(language='ru')
+    generator = generator(language='RU')
     generator.student.gender = gender
 
     template_context = generator.get_template_context()
@@ -29,7 +29,7 @@ def test_sex(generator, gender, expected):
 
 
 def test_user_name_ru(generator):
-    generator = generator(language='ru')
+    generator = generator(language='RU')
     generator.student.first_name = 'Авраам'
     generator.student.last_name = 'Линкольн'
 
@@ -39,7 +39,7 @@ def test_user_name_ru(generator):
 
 
 def test_user_name_en(generator):
-    generator = generator(language='en')
+    generator = generator(language='EN')
     generator.student.first_name_en = 'Abraham'
     generator.student.last_name_en = 'Lincoln'
 
@@ -51,7 +51,7 @@ def test_user_name_en(generator):
 def test_additional_course_context(generator, course):
     course.setattr_and_save('diploma_template_context', {'test': '__mocked'})
 
-    generator = generator(language='ru')
+    generator = generator(language='RU')
 
     template_context = generator.get_template_context()
 
@@ -59,7 +59,7 @@ def test_additional_course_context(generator, course):
 
 
 def test_bad_language(generator):
-    generator = generator(language='en')
+    generator = generator(language='EN')
 
     with pytest.raises(DiplomaTemplate.DoesNotExist):
         generator.get_external_service_url()
@@ -69,7 +69,7 @@ def test_no_template_for_homework(generator, order):
     order.study.homework_accepted = True
     order.study.save()
 
-    generator = generator(language='ru')
+    generator = generator(language='RU')
 
     with pytest.raises(DiplomaTemplate.DoesNotExist):
         generator.get_external_service_url()
@@ -78,6 +78,6 @@ def test_no_template_for_homework(generator, order):
 def test_external_service_url(generator, settings):
     settings.DIPLOMA_GENERATOR_HOST = 'https://secret.generator.com/'
 
-    generator = generator(language='ru')
+    generator = generator(language='RU')
 
     assert generator.get_external_service_url() == 'https://secret.generator.com/test-template.png'

--- a/src/diplomas/tests/diploma_generator/tests_diploma_generator_unit.py
+++ b/src/diplomas/tests/diploma_generator/tests_diploma_generator_unit.py
@@ -1,6 +1,7 @@
 import pytest
 
 from diplomas.models import DiplomaTemplate
+from users.models import User
 
 pytestmark = [
     pytest.mark.django_db,
@@ -16,8 +17,8 @@ def test_study_object(generator, order):
 @pytest.mark.parametrize(('gender', 'expected'), [
     ('', 'm'),
     (None, 'm'),
-    ('female', 'f'),
-    ('male', 'm'),
+    (User.GENDERS.FEMALE, 'f'),
+    (User.GENDERS.MALE, 'm'),
 ])
 def test_sex(generator, gender, expected):
     generator = generator(language='RU')

--- a/src/diplomas/tests/diploma_queryset/test_diploma_filter_with_template.py
+++ b/src/diplomas/tests/diploma_queryset/test_diploma_filter_with_template.py
@@ -23,25 +23,25 @@ def test_diploma_with_template_in_query(diploma, query):
     assert diploma in diplomas
 
 
-def test_exclude_diplomas_not_matching_template_course(mixer, query, template):
+def test_exclude_diplomas_not_matching_template_course(mixer, query, template, diploma):
     template.setattr_and_save('course', mixer.blend('products.Course'))
 
     diplomas = query()
 
-    assert diplomas.count() == 0
+    assert diploma not in diplomas
 
 
-def test_exclude_diplomas_not_matching_template_language(query, template):
+def test_exclude_diplomas_not_matching_template_language(query, template, diploma):
     template.setattr_and_save('language', 'EN')
 
     diplomas = query()
 
-    assert diplomas.count() == 0
+    assert diploma not in diplomas
 
 
-def test_exclude_diplomas_not_matching_template_homework_accepted(query, template):
+def test_exclude_diplomas_not_matching_template_homework_accepted(query, template, diploma):
     template.setattr_and_save('homework_accepted', True)
 
     diplomas = query()
 
-    assert diplomas.count() == 0
+    assert diploma not in diplomas

--- a/src/diplomas/tests/diploma_queryset/test_diploma_filter_with_template.py
+++ b/src/diplomas/tests/diploma_queryset/test_diploma_filter_with_template.py
@@ -1,0 +1,47 @@
+import pytest
+
+from diplomas.models import Diploma
+
+pytestmark = [
+    pytest.mark.django_db,
+]
+
+
+@pytest.fixture(autouse=True)
+def diploma(mixer, order):
+    return mixer.blend('diplomas.Diploma', study=order.study, language='RU')
+
+
+@pytest.fixture
+def query():
+    return lambda: Diploma.objects.filter_with_template()
+
+
+def test_diploma_with_template_in_query(diploma, query):
+    diplomas = query()
+
+    assert diploma in diplomas
+
+
+def test_exclude_diplomas_not_matching_template_course(mixer, query, template):
+    template.setattr_and_save('course', mixer.blend('products.Course'))
+
+    diplomas = query()
+
+    assert diplomas.count() == 0
+
+
+def test_exclude_diplomas_not_matching_template_language(query, template):
+    template.setattr_and_save('language', 'EN')
+
+    diplomas = query()
+
+    assert diplomas.count() == 0
+
+
+def test_exclude_diplomas_not_matching_template_homework_accepted(query, template):
+    template.setattr_and_save('homework_accepted', True)
+
+    diplomas = query()
+
+    assert diplomas.count() == 0

--- a/src/diplomas/tests/diploma_queryset/test_diploma_filter_with_template.py
+++ b/src/diplomas/tests/diploma_queryset/test_diploma_filter_with_template.py
@@ -1,6 +1,6 @@
 import pytest
 
-from diplomas.models import Diploma
+from diplomas.models import Diploma, Languages
 
 pytestmark = [
     pytest.mark.django_db,
@@ -9,7 +9,7 @@ pytestmark = [
 
 @pytest.fixture(autouse=True)
 def diploma(mixer, order):
-    return mixer.blend('diplomas.Diploma', study=order.study, language='RU')
+    return mixer.blend('diplomas.Diploma', study=order.study, language=Languages.RU)
 
 
 @pytest.fixture
@@ -32,7 +32,7 @@ def test_exclude_diplomas_not_matching_template_course(mixer, query, template, d
 
 
 def test_exclude_diplomas_not_matching_template_language(query, template, diploma):
-    template.setattr_and_save('language', 'EN')
+    template.setattr_and_save('language', Languages.EN)
 
     diplomas = query()
 

--- a/src/diplomas/tests/tests_diploma_regenerator.py
+++ b/src/diplomas/tests/tests_diploma_regenerator.py
@@ -1,71 +1,103 @@
 import pytest
 
 from diplomas import tasks
-from diplomas.models import DiplomaTemplate
+from diplomas.models import Diploma
 from diplomas.services import DiplomaRegenerator
 
 pytestmark = [
     pytest.mark.django_db,
-    pytest.mark.skip(reason='fixme'),
 ]
 
 
 @pytest.fixture(autouse=True)
-def diploma_generator(mocker):
-    return mocker.patch('diplomas.services.diploma_regenerator.DiplomaGenerator.__init__', return_value=None)
+def _mock_diploma_generator_fetch_image(mocker, factory):
+    image = factory.uploaded_image()
+    mocker.patch('diplomas.services.diploma_regenerator.DiplomaGenerator.fetch_image', return_value=image)
 
 
 @pytest.fixture(autouse=True)
-def run_diploma_generation(mocker):
-    return mocker.patch('diplomas.services.diploma_generator.DiplomaGenerator.__call__')
-
-
-@pytest.fixture(autouse=True)
-def diploma_ru(mixer, order):
-    return mixer.blend('diplomas.Diploma', study=order.study, language='ru')
-
-
-@pytest.fixture(autouse=True)
-def diploma_en(mixer, order):
-    return mixer.blend('diplomas.Diploma', study=order.study, language='en')
+def template_en(mixer, course):
+    return mixer.blend('diplomas.DiplomaTemplate', slug='test-template', course=course, language='EN', homework_accepted=False)
 
 
 @pytest.fixture
-def send_mail(mocker):
-    return mocker.patch('mailing.tasks.Owl.send')
+def diploma_ru(mixer, order):
+    return mixer.blend('diplomas.Diploma', study=order.study, language='RU')
 
 
-def test_diplomas_are_regenerated(student, course, diploma_generator, mocker, order):
+@pytest.fixture
+def diploma_en(mixer, order):
+    return mixer.blend('diplomas.Diploma', study=order.study, language='EN')
+
+
+@pytest.fixture
+def mock_diploma_generator(mocker):
+    return mocker.patch('diplomas.services.diploma_generator.DiplomaGenerator.__call__', autospec=True)
+
+
+@pytest.fixture
+def mock_diploma_regenerator(mocker):
+    return mocker.patch('diplomas.services.diploma_regenerator.DiplomaRegenerator.__call__', autospec=True)
+
+
+def test_diplomas_are_regenerated(student, course, diploma_ru, diploma_en, order):
     DiplomaRegenerator(student)()
 
-    diploma_generator.assert_has_calls(mocker.call(course=course, student=student, language='ru'))
-    diploma_generator.assert_has_calls(mocker.call(course=course, student=student, language='en'))
+    diploma_ru.refresh_from_db()
+    assert diploma_ru.modified is not None
+    diploma_en.refresh_from_db()
+    assert diploma_en.modified is not None
 
 
-def test_task(student, course, diploma_generator, mocker, order):
+def test_task_diplomas_regenerated(student, course, order, diploma_ru, diploma_en):
     tasks.regenerate_diplomas.delay(student_id=student.id)
 
-    diploma_generator.assert_has_calls(mocker.call(course=course, student=student, language='ru'))
-    diploma_generator.assert_has_calls(mocker.call(course=course, student=student, language='en'))
+    diploma_ru.refresh_from_db()
+    assert diploma_ru.modified is not None
+    diploma_en.refresh_from_db()
+    assert diploma_en.modified is not None
 
 
-def test_sky_does_not_fall_if_there_is_no_template_for_generated_diploma(student, run_diploma_generation, send_mail):
-    run_diploma_generation.side_effect = DiplomaTemplate.DoesNotExist
+def test_task_call_regenerator(student, course, order, diploma_ru, mock_diploma_regenerator):
+    tasks.regenerate_diplomas.delay(student_id=student.id)
+
+    mock_diploma_regenerator.assert_called_once()
+    called_service = mock_diploma_regenerator.call_args.args[0]
+    assert called_service.student == student
+
+
+def test_do_nothing_if_no_template_for_generated_diploma(student, template, diploma_ru, send_mail):
+    template.delete()
 
     DiplomaRegenerator(student)()
 
+    diploma_ru.refresh_from_db()
+    assert diploma_ru.modified is None
     send_mail.assert_not_called()
 
 
-def test_emai_is_sent(send_mail, student):
+def test_email_is_sent(send_mail, student, diploma_ru, diploma_en):
     DiplomaRegenerator(student)()
 
-    send_mail.assert_called_once()
+    send_mail.assert_called_once_with(
+        to=student.email,
+        template_id='diplomas_regenerated',
+        disable_antispam=True,
+    )
 
 
-def test_no_diplomas_are_generated_when_there_are_no_diploams_for_user(another_user, diploma_generator, send_mail):
+def test_diploma_generator_service_is_called(student, course, diploma_ru, mock_diploma_generator):
+    DiplomaRegenerator(student)()
+
+    mock_diploma_generator.assert_called()
+    called_service = mock_diploma_generator.call_args.args[0]
+    assert called_service.course == course
+    assert called_service.student == student
+    assert called_service.language == 'RU'
+
+
+def test_no_diplomas_are_generated_when_there_are_no_diplomas_for_user(another_user, send_mail):
     DiplomaRegenerator(another_user)()
 
-    diploma_generator.assert_not_called()
-
+    assert Diploma.objects.count() == 0
     send_mail.assert_not_called()

--- a/src/diplomas/tests/tests_diploma_regenerator.py
+++ b/src/diplomas/tests/tests_diploma_regenerator.py
@@ -44,8 +44,8 @@ def test_diplomas_are_regenerated(student, course, diploma_ru, diploma_en, order
     DiplomaRegenerator(student)()
 
     diploma_ru.refresh_from_db()
-    assert diploma_ru.modified is not None
     diploma_en.refresh_from_db()
+    assert diploma_ru.modified is not None
     assert diploma_en.modified is not None
 
 
@@ -53,8 +53,8 @@ def test_task_diplomas_regenerated(student, course, order, diploma_ru, diploma_e
     tasks.regenerate_diplomas.delay(student_id=student.id)
 
     diploma_ru.refresh_from_db()
-    assert diploma_ru.modified is not None
     diploma_en.refresh_from_db()
+    assert diploma_ru.modified is not None
     assert diploma_en.modified is not None
 
 

--- a/src/diplomas/tests/tests_diploma_regenerator.py
+++ b/src/diplomas/tests/tests_diploma_regenerator.py
@@ -1,7 +1,7 @@
 import pytest
 
 from diplomas import tasks
-from diplomas.models import Diploma
+from diplomas.models import Diploma, Languages
 from diplomas.services import DiplomaRegenerator
 
 pytestmark = [
@@ -17,17 +17,23 @@ def _mock_diploma_generator_fetch_image(mocker, factory):
 
 @pytest.fixture(autouse=True)
 def template_en(mixer, course):
-    return mixer.blend('diplomas.DiplomaTemplate', slug='test-template', course=course, language='EN', homework_accepted=False)
+    return mixer.blend(
+        'diplomas.DiplomaTemplate',
+        slug='test-template',
+        course=course,
+        language=Languages.EN,
+        homework_accepted=False,
+    )
 
 
 @pytest.fixture
 def diploma_ru(mixer, order):
-    return mixer.blend('diplomas.Diploma', study=order.study, language='RU')
+    return mixer.blend('diplomas.Diploma', study=order.study, language=Languages.RU)
 
 
 @pytest.fixture
 def diploma_en(mixer, order):
-    return mixer.blend('diplomas.Diploma', study=order.study, language='EN')
+    return mixer.blend('diplomas.Diploma', study=order.study, language=Languages.EN)
 
 
 @pytest.fixture
@@ -93,7 +99,7 @@ def test_diploma_generator_service_is_called(student, course, diploma_ru, mock_d
     called_service = mock_diploma_generator.call_args.args[0]
     assert called_service.course == course
     assert called_service.student == student
-    assert called_service.language == 'RU'
+    assert called_service.language == Languages.RU
 
 
 def test_no_diplomas_are_generated_when_there_are_no_diplomas_for_user(another_user, send_mail):

--- a/src/orders/services/order_diploma_generator.py
+++ b/src/orders/services/order_diploma_generator.py
@@ -5,6 +5,7 @@ from diplomas.models import DiplomaTemplate
 from diplomas.tasks import generate_diploma
 from orders.models import Order
 from products.models import Course
+from studying.models import Study
 from users.models import User
 
 
@@ -22,15 +23,25 @@ class OrderDiplomaGenerator:
                 )
 
     @cached_property
+    def study(self) -> Study:
+        return self.order.study
+
+    @cached_property
     def student(self) -> User:
-        return self.order.user
+        return self.study.student
 
     @cached_property
     def course(self) -> Course:
-        return self.order.study.course
+        return self.study.course
 
     def get_available_languages(self) -> list[str]:
-        return [template.language for template in DiplomaTemplate.objects.filter(course=self.course)]
+        return [
+            template.language
+            for template in DiplomaTemplate.objects.filter(
+                course=self.course,
+                homework_accepted=self.study.homework_accepted,
+            )
+        ]
 
     def order_is_suitable_for_diploma_generation(self, language) -> bool:
         return self.student.get_printable_name(language=language) is not None

--- a/src/orders/tests/test_order_item_constraints.py
+++ b/src/orders/tests/test_order_item_constraints.py
@@ -2,6 +2,7 @@ import pytest
 from django.db.utils import IntegrityError
 
 from orders.models.order import Order
+from users.models import User
 
 pytestmark = [pytest.mark.django_db]
 
@@ -23,7 +24,7 @@ def bundle(mixer):
 
 @pytest.fixture
 def student(mixer):
-    return mixer.blend('users.User', first_name='Омон', last_name='Кривомазов', gender='male')
+    return mixer.blend('users.User', first_name='Омон', last_name='Кривомазов', gender=User.GENDERS.MALE)
 
 
 def test_order_constraints_check_product_with_two_items(student, record, course):

--- a/src/orders/tests/tests_order_diploma_generator.py
+++ b/src/orders/tests/tests_order_diploma_generator.py
@@ -61,3 +61,11 @@ def test_student_without_a_name_does_not_get_the_diploma(diploma_generator, orde
     tasks.generate_diploma.delay(order_id=order.id)
 
     diploma_generator.assert_not_called()
+
+
+def test_do_not_generate_diploma_for_order_not_matched_homework_accepted(diploma_generator, template, order):
+    template.setattr_and_save('homework_accepted', True)
+
+    OrderDiplomaGenerator(order=order)()
+
+    diploma_generator.assert_not_called()

--- a/src/orders/tests/tests_order_diploma_generator.py
+++ b/src/orders/tests/tests_order_diploma_generator.py
@@ -1,14 +1,16 @@
 import pytest
 
+from diplomas.models import Languages
 from orders import tasks
 from orders.services import OrderDiplomaGenerator
+from users.models import User
 
 pytestmark = [pytest.mark.django_db]
 
 
 @pytest.fixture
 def student(mixer):
-    return mixer.blend('users.User', first_name='Омон', last_name='Кривомазов', gender='male')
+    return mixer.blend('users.User', first_name='Омон', last_name='Кривомазов', gender=User.GENDERS.MALE)
 
 
 @pytest.fixture
@@ -23,7 +25,13 @@ def order(factory, course, student):
 
 @pytest.fixture(autouse=True)
 def template(mixer, course):
-    return mixer.blend('diplomas.DiplomaTemplate', slug='test-template', course=course, language='RU', homework_accepted=False)
+    return mixer.blend(
+        'diplomas.DiplomaTemplate',
+        slug='test-template',
+        course=course,
+        language=Languages.RU,
+        homework_accepted=False,
+    )
 
 
 @pytest.fixture
@@ -31,7 +39,7 @@ def diploma_generator(mocker):
     return mocker.patch('orders.services.order_diploma_generator.generate_diploma.delay')
 
 
-@pytest.mark.parametrize('language', ['RU', 'EN'])
+@pytest.mark.parametrize('language', [Languages.RU, Languages.EN])
 def test_single_language(diploma_generator, order, student, course, template, language):
     template.language = language
     template.save()

--- a/src/users/tests/api/tests_user_self_view.py
+++ b/src/users/tests/api/tests_user_self_view.py
@@ -1,5 +1,7 @@
 import pytest
 
+from users.models import User
+
 pytestmark = [pytest.mark.django_db]
 
 
@@ -49,13 +51,13 @@ def test_edit_user_data_in_english(api):
 
 
 def test_edit_gender(api):
-    api.user.gender = 'male'
+    api.user.gender = User.GENDERS.MALE
     api.user.save()
 
     api.patch('/api/v2/users/me/', {'gender': 'female'})
 
     api.user.refresh_from_db()
-    assert api.user.gender == 'female'
+    assert api.user.gender == User.GENDERS.FEMALE
 
 
 @pytest.mark.parametrize('field', ['github_username', 'linkedin_username'])

--- a/src/users/tests/management/merge_same_email_users/test_user_merge.py
+++ b/src/users/tests/management/merge_same_email_users/test_user_merge.py
@@ -1,6 +1,8 @@
 import pytest
 from mixer.backend.django import mixer
 
+from users.models import User
+
 pytestmark = pytest.mark.django_db
 
 
@@ -28,7 +30,7 @@ def test_merged_user_has_email_lowered(bob_a, bob_b, command):
     ('first_name_en', 'Bob', ''),
     ('last_name_en', 'McBob', ''),
     ('subscribed', True, False),
-    ('gender', 'male', ''),
+    ('gender', User.GENDERS.MALE, ''),
 ])
 def test_target_user_populates_empty_property(bob_a, bob_b, command, prop_name, prop_value, empty_value):
     setattr(bob_a, prop_name, prop_value)
@@ -47,7 +49,7 @@ def test_target_user_populates_empty_property(bob_a, bob_b, command, prop_name, 
     ('first_name_en', 'Bob', ''),
     ('last_name_en', 'McBob', ''),
     ('subscribed', True, False),
-    ('gender', 'male', ''),
+    ('gender', User.GENDERS.MALE, ''),
 ])
 def test_target_user_preserves_non_empty_property(bob_a, bob_b, command, prop_name, prop_value, empty_value):
     setattr(bob_a, prop_name, empty_value)

--- a/src/users/tests/tests_user_printable_gender.py
+++ b/src/users/tests/tests_user_printable_gender.py
@@ -1,14 +1,16 @@
 import pytest
 
+from users.models import User
+
 pytestmark = [pytest.mark.django_db]
 
 
 @pytest.mark.parametrize(('gender', 'expected'), [
-    ('male', 'male'),
-    ('female', 'female'),
+    (User.GENDERS.MALE, 'male'),
+    (User.GENDERS.FEMALE, 'female'),
     ('', 'male'),
 ])
-def test(mixer, gender, expected):
+def test_printable_gender(mixer, gender, expected):
     user = mixer.blend('users.User', gender=gender)
 
     assert user.get_printable_gender() == expected


### PR DESCRIPTION
Вместо подавления ошибки обрабатываем только дипломы с шаблонами.
Обсуждаем вот тут: https://github.com/tough-dev-school/education-backend/pull/1291

Изначальная ошибка почему код появился: https://github.com/tough-dev-school/education-backend/issues/816

Что ещё: немного приблизил тесты `DiplomaRegenerator` к реальности — смотрим что дипломы обновились, вместо моков