### PR TITLE
CI: do not run install dependencies when hit cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,14 @@ jobs:
           python-version-file: '.python-version'
 
       - uses: actions/cache@v3
+        id: cache-dependencies
         with:
           path: |
             venv
           key: ${{ runner.os }}-venv-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/*requirements.txt') }}
 
       - name: Install dependencies
-        if: steps.cache-primes.outputs.cache-hit != 'true'
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: |
           python -m venv venv
           . venv/bin/activate


### PR DESCRIPTION
Сейчас шаг установки зависимостей запускается всегда, независимо есть кэш или нет

Такое поведение из-за того, что проверяется результат в шаге `cache-primes` (которого в нашем CI нет).
Скорее эта строка [из примера в документации ](https://github.com/actions/cache#example-workflow)

Логично
1. либо удалить `if`, чтобы не смущало и установка запускалась всегда (как сейчас)
2. либо, как в документации, добавить `id` для шага с кэшированием и проверять результат

Сделал вариант 2
