### PR TITLE
Disable cache for sure, disable `django-cashalot` cache in tests

### DIFF
--- a/src/app/conf/cache.py
+++ b/src/app/conf/cache.py
@@ -1,15 +1,17 @@
 from app.conf.environ import env
 
-CACHES = {
-    'default': env.cache('REDISCLOUD_URL'),
-}
-
 if env('NO_CACHE', cast=bool, default=False):
     CACHES = {
         'default': {
             'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
         },
     }
+    CACHALOT_ENABLED = False  # Just disabled explicitly. If enabled here it will not work cause the cache backend is DummyCache.
+else:
+    CACHES = {
+        'default': env.cache('REDISCLOUD_URL'),
+    }
+
 
 if env('CI', cast=bool, default=False):
     CACHALOT_ENABLED = False  # disable `django-cachalot` in tests https://github.com/noripyt/django-cachalot/issues/126

--- a/src/app/conf/cache.py
+++ b/src/app/conf/cache.py
@@ -11,10 +11,10 @@ if env('NO_CACHE', cast=bool, default=False):
         },
     }
 
-CACHALOT_ENABLED = env('CACHALOT_ENABLED', cast=bool, default=True)
+if env('CI', cast=bool, default=False):
+    CACHALOT_ENABLED = False  # disable `django-cachalot` in tests https://github.com/noripyt/django-cachalot/issues/126
+
 CACHALOT_UNCACHABLE_TABLES = [
     'django_migrations',
     'django_content_type',
-    'orders_order',  # https://github.com/noripyt/django-cachalot/issues/126
-    'chains_progress',
 ]

--- a/src/app/conf/cache.py
+++ b/src/app/conf/cache.py
@@ -1,10 +1,17 @@
 from app.conf.environ import env
 
-if not env('NO_CACHE', cast=bool, default=False):
+CACHES = {
+    'default': env.cache('REDISCLOUD_URL'),
+}
+
+if env('NO_CACHE', cast=bool, default=False):
     CACHES = {
-        'default': env.cache('REDISCLOUD_URL'),
+        'default': {
+            'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+        },
     }
 
+CACHALOT_ENABLED = env('CACHALOT_ENABLED', cast=bool, default=True)
 CACHALOT_UNCACHABLE_TABLES = [
     'django_migrations',
     'django_content_type',

--- a/src/pytest.ini
+++ b/src/pytest.ini
@@ -15,7 +15,7 @@ filterwarnings =
 
 env =
   CI=1
-  NO_CACHE=1
+  CACHALOT_ENABLED=False
   CELERY_ALWAYS_EAGER=True
   AWS_ACCESS_KEY_ID=zeroc00l94
   AWS_SECRET_ACCESS_KEY=h4xx0r

--- a/src/pytest.ini
+++ b/src/pytest.ini
@@ -15,7 +15,6 @@ filterwarnings =
 
 env =
   CI=1
-  CACHALOT_ENABLED=False
   CELERY_ALWAYS_EAGER=True
   AWS_ACCESS_KEY_ID=zeroc00l94
   AWS_SECRET_ACCESS_KEY=h4xx0r

--- a/src/users/tests/test_freezegun_not_broken.py
+++ b/src/users/tests/test_freezegun_not_broken.py
@@ -1,0 +1,23 @@
+import pytest
+
+from users.models import User
+
+pytestmark = [
+    pytest.mark.django_db,
+]
+
+
+@pytest.mark.freeze_time('2022-11-23')
+def test_queryset_return_updated_data_while_time_freezed():
+    """
+    Django-cachalot uses time as a key for cache and does not compatible with `freezegun`.
+    Test to be sure that queryset returns updated data == cachalot is disabled.
+    More details: https://github.com/noripyt/django-cachalot/issues/126
+    """
+    created_user = User.objects.create(username='created_username')
+
+    fetched_user = User.objects.get(id=created_user.id)
+    fetched_user.username = 'updated_username'
+    fetched_user.save()
+
+    assert User.objects.get(id=created_user.id).username == 'updated_username'


### PR DESCRIPTION
https://3.basecamp.com/5104612/buckets/29069198/todos/5568018629 (в dev-контейнере с бэком для фронта приходят неактуальные данные)

Причина в in-memory кэшировании которое создает свой кэш для каждого процесса. Детали расписал в basecamp.

Что тут:
1. Переменной окружения `NO_CACHE` выключаем кэш (ранее выставляли значение по умолчанию, т.е `django.core.cache.backends.locmem.LocMemCache`)
2. Отключаем `django-cachalot` в тестах, но оставляем кэш.