### PR TITLE
Answers API: add `empty_descendants` query param

### DIFF
--- a/src/homework/api/serializers.py
+++ b/src/homework/api/serializers.py
@@ -40,6 +40,11 @@ class AnswerTreeSerializer(serializers.ModelSerializer):
         ]
 
     def get_descendants(self, obj):
+        descendants_disabled = self.context.get('descendants_disabled')
+
+        if descendants_disabled:
+            return []
+
         queryset = obj.get_first_level_descendants()
         serializer = AnswerTreeSerializer(
             queryset,

--- a/src/homework/api/viewsets.py
+++ b/src/homework/api/viewsets.py
@@ -31,10 +31,11 @@ class AnswerViewSet(AppViewSet):
 
     @property
     def pagination_disabled(self) -> bool:
-        return str(self.request.query_params.get('disable_pagination', False)).lower() in [
-            'true',
-            '1',
-        ]
+        return self.get_query_bool_value('disable_pagination')
+
+    @property
+    def descendants_disabled(self) -> bool:
+        return self.get_query_bool_value('empty_descendants')
 
     def update(self, request: Request, *args, **kwargs) -> Response:
         if not kwargs.get('partial', False):
@@ -91,3 +92,17 @@ class AnswerViewSet(AppViewSet):
                     user=self.request.user,
                     answer=answer,
                 )
+
+    def get_query_bool_value(self, query_param: str):
+        return str(self.request.query_params.get(query_param, False)).lower() in [
+            'true',
+            '1',
+        ]
+
+    def get_serializer_context(self) -> dict:
+        """Include `disable_descendants` in context to not return descendants if used."""
+
+        context = super().get_serializer_context()
+        context['descendants_disabled'] = self.descendants_disabled
+
+        return context


### PR DESCRIPTION
Query параметр, чтоб не загружать вложенные ответы.
https://3.basecamp.com/5104612/buckets/29069198/todos/5593338855

Реализовал через контекст в сериализаторе. Не оч нравится, т.к. пролезает в сериализатор.
Второй вариант: можно сделать второй сериализатор без потомков + переписать логику выбора сериализатора в зависимости от квэри параметра, но навскидку так получается сложнее.