### PR TITLE
Homework Answers API: has_descendants field

### DIFF
--- a/src/homework/api/serializers.py
+++ b/src/homework/api/serializers.py
@@ -52,7 +52,7 @@ class AnswerTreeSerializer(serializers.ModelSerializer):
         return cast(list[dict], serializer.data)
 
 
-class AnswerDetailedSerializer(AnswerTreeSerializer):
+class AnswerDetailedTreeSerializer(AnswerTreeSerializer):
     has_descendants = serializers.BooleanField(source='children_count')
 
     class Meta:

--- a/src/homework/api/serializers.py
+++ b/src/homework/api/serializers.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from rest_framework import serializers
 
 from app.serializers import MarkdownXField, SoftField
@@ -39,7 +41,7 @@ class AnswerTreeSerializer(serializers.ModelSerializer):
             'descendants',
         ]
 
-    def get_descendants(self, obj):
+    def get_descendants(self, obj: Answer) -> list[dict]:
         queryset = obj.get_first_level_descendants()
         serializer = AnswerTreeSerializer(
             queryset,
@@ -47,7 +49,26 @@ class AnswerTreeSerializer(serializers.ModelSerializer):
             context=self.context,
         )
 
-        return serializer.data
+        return cast(list[dict], serializer.data)
+
+
+class AnswerDetailedSerializer(AnswerTreeSerializer):
+    has_descendants = serializers.BooleanField(source='children_count')
+
+    class Meta:
+        model = Answer
+        fields = [
+            'created',
+            'modified',
+            'slug',
+            'question',
+            'author',
+            'parent',
+            'text',
+            'src',
+            'descendants',
+            'has_descendants',
+        ]
 
 
 class AnswerCreateSerializer(serializers.ModelSerializer):

--- a/src/homework/api/viewsets.py
+++ b/src/homework/api/viewsets.py
@@ -7,14 +7,14 @@ from app.viewsets import AppViewSet
 from homework.api.filtersets import AnswerFilterSet
 from homework.api.permissions import (
     MayChangeAnswerOnlyForLimitedTime, ShouldBeAnswerAuthorOrReadOnly, ShouldHavePurchasedQuestionCoursePermission)
-from homework.api.serializers import AnswerCreateSerializer, AnswerDetailedSerializer
+from homework.api.serializers import AnswerCreateSerializer, AnswerDetailedTreeSerializer
 from homework.models import Answer, AnswerAccessLogEntry
 from homework.models.answer import AnswerQuerySet
 
 
 class AnswerViewSet(AppViewSet):
     queryset = Answer.objects.for_viewset()
-    serializer_class = AnswerDetailedSerializer
+    serializer_class = AnswerDetailedTreeSerializer
     serializer_action_classes = {
         'create': AnswerCreateSerializer,
         'partial_update': AnswerCreateSerializer,

--- a/src/homework/api/viewsets.py
+++ b/src/homework/api/viewsets.py
@@ -7,14 +7,14 @@ from app.viewsets import AppViewSet
 from homework.api.filtersets import AnswerFilterSet
 from homework.api.permissions import (
     MayChangeAnswerOnlyForLimitedTime, ShouldBeAnswerAuthorOrReadOnly, ShouldHavePurchasedQuestionCoursePermission)
-from homework.api.serializers import AnswerCreateSerializer, AnswerTreeSerializer
+from homework.api.serializers import AnswerCreateSerializer, AnswerDetailedSerializer
 from homework.models import Answer, AnswerAccessLogEntry
 from homework.models.answer import AnswerQuerySet
 
 
 class AnswerViewSet(AppViewSet):
     queryset = Answer.objects.for_viewset()
-    serializer_class = AnswerTreeSerializer
+    serializer_class = AnswerDetailedSerializer
     serializer_action_classes = {
         'create': AnswerCreateSerializer,
         'partial_update': AnswerCreateSerializer,
@@ -53,8 +53,9 @@ class AnswerViewSet(AppViewSet):
         queryset = super().get_queryset()
 
         queryset = self.limit_queryset_to_user(queryset)  # type: ignore
+        queryset = self.limit_queryset_for_list(queryset)
 
-        return self.limit_queryset_for_list(queryset)
+        return queryset.with_children_count().order_by('created')
 
     def paginate_queryset(self, queryset):
         """Disable response pagination with query param `disable_pagination`."""

--- a/src/homework/tests/api/tests_answer_list.py
+++ b/src/homework/tests/api/tests_answer_list.py
@@ -19,14 +19,27 @@ def answer_from_another_user(another_user, another_answer):
 def test_ok(api, question, answer):
     got = api.get(f'/api/v2/homework/answers/?question={question.slug}')['results']
 
+    assert len(got[0]) == 9
     assert got[0]['created'] == '2022-10-09T10:30:12+12:00'
     assert got[0]['modified'] == '2022-10-09T10:30:12+12:00'
     assert got[0]['slug'] == str(answer.slug)
+    assert got[0]['question'] == str(answer.question.slug)
     assert '<em>test</em>' in got[0]['text']
     assert got[0]['src'] == '*test*'
     assert got[0]['author']['uuid'] == str(api.user.uuid)
     assert got[0]['author']['first_name'] == api.user.first_name
     assert got[0]['author']['last_name'] == api.user.last_name
+    assert got[0]['descendants'] == []
+    assert got[0]['has_descendants'] is False
+
+
+def test_has_descendants_is_true_if_answer_has_children(api, question, answer, another_answer):
+    another_answer.parent = answer
+    another_answer.save()
+
+    got = api.get(f'/api/v2/homework/answers/?question={question.slug}')['results']
+
+    assert got[0]['has_descendants'] is True
 
 
 @pytest.mark.usefixtures('answer')

--- a/src/homework/tests/api/tests_answer_tree_retrieve.py
+++ b/src/homework/tests/api/tests_answer_tree_retrieve.py
@@ -39,9 +39,26 @@ def test_no_descendants_by_default(api, answer):
 def test_child_answers(api, answer, another_answer):
     got = api.get(f'/api/v2/homework/answers/{answer.slug}/')
 
-    assert got['descendants'][0]['slug'] == str(another_answer.slug)
-    assert got['descendants'][0]['author']['first_name'] == another_answer.author.first_name
-    assert got['descendants'][0]['author']['last_name'] == another_answer.author.last_name
+    assert len(got['descendants']) == 1
+
+
+@pytest.mark.freeze_time('2022-10-09 10:30:12+12:00')  # +12 hours kamchatka timezone
+@pytest.mark.usefixtures('kamchatka_timezone')
+def test_childe_answer_fields(api, answer, another_answer):
+    got = api.get(f'/api/v2/homework/answers/{answer.slug}/')['descendants'][0]
+
+    assert len(got) == 9
+    assert got['created'] == '2022-10-09T10:30:12+12:00'
+    assert got['modified'] == '2022-10-09T10:30:12+12:00'
+    assert got['slug'] == str(another_answer.slug)
+    assert got['parent'] == str(answer.slug)
+    assert got['question'] == str(another_answer.question.slug)
+    assert got['author']['uuid'] == str(another_answer.author.uuid)
+    assert got['author']['first_name'] == another_answer.author.first_name
+    assert got['author']['last_name'] == another_answer.author.last_name
+    assert 'text' in got
+    assert 'src' in got
+    assert 'descendants' in got
 
 
 def test_multilevel_child_answers(api, answer, another_answer, child_of_another_answer):

--- a/src/homework/tests/api/tests_answer_tree_retrieve.py
+++ b/src/homework/tests/api/tests_answer_tree_retrieve.py
@@ -44,7 +44,7 @@ def test_child_answers(api, answer, another_answer):
 
 @pytest.mark.freeze_time('2022-10-09 10:30:12+12:00')  # +12 hours kamchatka timezone
 @pytest.mark.usefixtures('kamchatka_timezone')
-def test_childe_answer_fields(api, answer, another_answer):
+def test_child_answers_fields(api, answer, another_answer):
     got = api.get(f'/api/v2/homework/answers/{answer.slug}/')['descendants'][0]
 
     assert len(got) == 9


### PR DESCRIPTION
Поле есть или нет комментарии у ответа. Задача [в basecamp](https://3.basecamp.com/5104612/buckets/29069198/todos/5675562465)

Сделал поле булевым: посчитать количество комментариев просто получается только через `n+1` запрос, что не хотелось бы.

Немного подправил тесты:
 1. явные проверки какие поля в API у `answer`, какие у комментария (`descendant`)
 2. Тест, что у корневого ответа нет `parent` поменял на обратный: что у наследника показываем `parent`