### PR TITLE
Disable pagination query param for diplomas API

### DIFF
--- a/src/app/api/mixins.py
+++ b/src/app/api/mixins.py
@@ -1,0 +1,34 @@
+from typing import Any, Protocol, Sequence
+
+from django.db.models import QuerySet
+from rest_framework.request import Request
+
+
+class BaseListAPIView(Protocol):
+    @property
+    def pagination_disabled(self) -> bool:
+        ...
+
+    @property
+    def request(self) -> Request:
+        ...
+
+    def paginate_queryset(self, queryset: QuerySet | Sequence[Any]) -> None | Sequence[Any]:
+        ...
+
+
+class DisablePaginationWithQueryParamMixin:
+    """Add ability to disable response pagination with `disable_pagination=True` query param."""
+
+    @property
+    def pagination_disabled(self: BaseListAPIView) -> bool:
+        return str(self.request.query_params.get('disable_pagination', False)).lower() in [
+            'true',
+            '1',
+        ]
+
+    def paginate_queryset(self: BaseListAPIView, queryset: QuerySet | Sequence[Any]) -> None | Sequence[Any]:
+        if self.pagination_disabled:
+            return None
+
+        return super().paginate_queryset(queryset)  # type: ignore

--- a/src/diplomas/api/viewsets.py
+++ b/src/diplomas/api/viewsets.py
@@ -1,13 +1,14 @@
 
 from rest_framework.exceptions import MethodNotAllowed
 
+from app.api.mixins import DisablePaginationWithQueryParamMixin
 from app.viewsets import AppViewSet
 from diplomas.api import serializers
 from diplomas.api.permissions import DiplomaPermission
 from diplomas.models import Diploma
 
 
-class DiplomaViewSet(AppViewSet):
+class DiplomaViewSet(DisablePaginationWithQueryParamMixin, AppViewSet):
     queryset = Diploma.objects.for_viewset()
     lookup_field = 'slug'
     serializer_class = serializers.DiplomaSerializer

--- a/src/diplomas/tests/api/tests_diploma_list.py
+++ b/src/diplomas/tests/api/tests_diploma_list.py
@@ -15,10 +15,13 @@ def test_ok(api, diploma):
 
     got = api.get('/api/v2/diplomas/')['results']
 
+    assert len(got[0]) == 6
     assert diploma.slug in got[0]['url']
     assert got[0]['slug'] == diploma.slug
     assert got[0]['student']['uuid'] == str(diploma.study.student.uuid)
     assert got[0]['course']['name'] == diploma.study.course.name
+    assert got[0]['language'] == diploma.language
+    assert '.gif' in got[0]['image']
 
 
 def test_no_diplomas_of_other_users(api):
@@ -27,7 +30,7 @@ def test_no_diplomas_of_other_users(api):
     assert len(got) == 0
 
 
-def test_superuser_can_access_diploams_of_other_users(api):
+def test_superuser_can_access_diplomas_of_other_users(api):
     api.user.is_superuser = True
     api.user.save()
 
@@ -36,9 +39,38 @@ def test_superuser_can_access_diploams_of_other_users(api):
     assert len(got) == 1
 
 
-def test_user_with_permission_can_access_diploms_of_other_users(api):
+def test_user_with_permission_can_access_diplomas_of_other_users(api):
     api.user.add_perm('diplomas.diploma.access_all_diplomas')
 
     got = api.get('/api/v2/diplomas/')['results']
 
     assert len(got) == 1
+
+
+@pytest.mark.parametrize('disable_pagination_value', [
+    'True',
+    'true',
+    '1',
+])
+def test_pagination_could_be_disable_with_query_param(api, diploma, disable_pagination_value):
+    api.auth(diploma.study.student)
+
+    got = api.get(f'/api/v2/diplomas/?disable_pagination={disable_pagination_value}')
+
+    assert len(got) == 1
+    assert got[0]['slug'] == diploma.slug
+
+
+@pytest.mark.parametrize('disable_pagination_value', [
+    'false',
+    'False',
+    'any-other-value',
+])
+def test_paginated_response_with_disable_pagination_false_or_invalid_value(api, diploma, disable_pagination_value):
+    api.auth(diploma.study.student)
+
+    got = api.get(f'/api/v2/diplomas/?disable_pagination={disable_pagination_value}')
+
+    assert 'results' in got
+    assert 'count' in got
+    assert len(got['results']) == 1

--- a/src/studying/api/views.py
+++ b/src/studying/api/views.py
@@ -2,13 +2,14 @@ from django.db.models import QuerySet
 from rest_framework.generics import ListAPIView
 from rest_framework.permissions import IsAuthenticated
 
+from app.api.mixins import DisablePaginationWithQueryParamMixin
 from app.views import AuthenticatedRequest
 from products.models import Course
 from studying.api.serializers import CourseSerializer
 from studying.models import Study
 
 
-class PurchasedCoursesView(ListAPIView):
+class PurchasedCoursesView(DisablePaginationWithQueryParamMixin, ListAPIView):
     serializer_class = CourseSerializer
     permission_classes = [IsAuthenticated]
     request: AuthenticatedRequest

--- a/src/studying/tests/api/test_purchased_courses_view.py
+++ b/src/studying/tests/api/test_purchased_courses_view.py
@@ -31,3 +31,28 @@ def test_list_excludes_courses_that_should_not_be_displayed_in_lms(api, course):
 
 def test_no_anon(anon):
     anon.get('/api/v2/studies/purchased/', expected_status_code=401)
+
+
+@pytest.mark.parametrize('disable_pagination_value', [
+    'True',
+    'true',
+    '1',
+])
+def test_pagination_could_be_disable_with_query_param(api, course, disable_pagination_value):
+    got = api.get(f'/api/v2/studies/purchased/?disable_pagination={disable_pagination_value}')
+
+    assert len(got) == 1
+    assert got[0]['id'] == course.id
+
+
+@pytest.mark.parametrize('disable_pagination_value', [
+    'false',
+    'False',
+    'any-other-value',
+])
+def test_paginated_response_with_disable_pagination_false_or_invalid_value(api, course, disable_pagination_value):
+    got = api.get(f'/api/v2/studies/purchased/?disable_pagination={disable_pagination_value}')
+
+    assert 'results' in got
+    assert 'count' in got
+    assert len(got['results']) == 1


### PR DESCRIPTION
Задача https://3.basecamp.com/5104612/buckets/29069198/todos/5767346539

Три вещи:
1. Отключение паджинации в API списке дипломов `/diplomas/`
2. Отключение паджинации в API списке купленных курсов `/studies/purchases/`
3.. Отключение паджинации сделал миксином, т.к
     1. используем в 3-ех API вьюхах
     2. Проще выпилить когда перестанет быть нужным