### PR TITLE
Notion API: drop `last-modified` headers

### DIFF
--- a/src/notion/api/views.py
+++ b/src/notion/api/views.py
@@ -1,5 +1,3 @@
-from typing import Any, Optional
-
 from django.db.models import QuerySet
 from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
@@ -11,7 +9,6 @@ from notion.api.throttling import NotionThrottle
 from notion.cache import get_cached_page
 from notion.helpers import uuid_to_id
 from notion.models import Material
-from notion.page import NotionPage
 from studying.models import Study
 
 
@@ -29,10 +26,9 @@ class NotionMaterialView(AuthenticatedAPIView):
         return Response(
             data=NotionPageSerializer(page).data,
             status=200,
-            headers=self.get_headers(page),
         )
 
-    def get_material(self) -> Optional[Material]:
+    def get_material(self) -> Material | None:
         queryset = self.get_queryset()
 
         return queryset.filter(page_id=self.page_id).first()
@@ -43,15 +39,6 @@ class NotionMaterialView(AuthenticatedAPIView):
 
         available_courses = Study.objects.filter(student=self.request.user).values('course')
         return Material.objects.filter(active=True, course__in=available_courses)
-
-    @staticmethod
-    def get_headers(page: NotionPage) -> dict:
-        headers: dict[str, Any] = dict()
-
-        if page.last_modified is not None:
-            headers['last-modified'] = page.last_modified.strftime('%a, %d %b %Y %H:%M:%S %Z')
-
-        return headers
 
     @property
     def page_id(self) -> str:

--- a/src/notion/tests/api/test_notion_material_api.py
+++ b/src/notion/tests/api/test_notion_material_api.py
@@ -13,12 +13,6 @@ def test_both_formats_work(api, material_id, mock_notion_response):
     mock_notion_response.assert_called_once_with('0e5693d2173a4f77ae8106813b6e5329')
 
 
-def test_last_modified_header(api, material):
-    got = api.get(f'/api/v2/notion/materials/{material.page_id}/', as_response=True)
-
-    assert got.headers['Last-Modified'] == 'Sun, 16 Jan 2022 21:11:00 UTC'
-
-
 def test_content_is_passed_from_notion_client(api, material):
     got = api.get(f'/api/v2/notion/materials/{material.page_id}/')
 
@@ -39,11 +33,3 @@ def test_404_for_inactive_materials(api, mock_notion_response, material):
     api.get('/api/v2/notion/materials/0e5693d2173a4f77ae8106813b6e5329/', expected_status_code=404)
 
     mock_notion_response.assert_not_called()
-
-
-def test_page_without_last_modified_does_not_break_things(api, material, mocker):
-    mocker.patch('notion.block.NotionBlock.last_modified', new_callable=mocker.PropertyMock, return_value=None)
-
-    got = api.get(f'/api/v2/notion/materials/{material.page_id}/', as_response=True)
-
-    assert 'last-modified' not in got.headers


### PR DESCRIPTION
Задача в basecamp: https://3.basecamp.com/5104612/buckets/29069198/todos/5826457042

Сейчас просто удаляю заголовки, которые предположительно влияют на локальный кэш и не отдаются новые материалы курса. С большое долей вероятности это поможет.

В задаче ещё разберусь подробнее: хочу сымитировать ошибку и понять чем `Last-Modified` мешает, т.к ошибок когда проставляем заголовок не увидел. 