### PR TITLE
Refactor the `uploaded_image` fixture

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -167,7 +167,7 @@ execnet==1.9.0
     # via pytest-xdist
 executing==1.2.0
     # via stack-data
-faker==4.0.0
+faker==12.0.1
     # via mixer
 flake8==5.0.4
     # via
@@ -276,7 +276,7 @@ matplotlib-inline==0.1.6
     # via ipython
 mccabe==0.7.0
     # via flake8
-mixer==7.0.6
+mixer==7.2.2
     # via education-backend (pyproject.toml)
 mypy==0.950
     # via
@@ -297,6 +297,8 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
+pillow==9.4.0
+    # via education-backend (pyproject.toml)
 platformdirs==3.1.1
     # via black
 pluggy==1.0.0
@@ -418,8 +420,6 @@ standardjson==0.3.1
     # via django-prettyjson
 stripe==5.2.0
     # via education-backend (pyproject.toml)
-text-unidecode==1.3
-    # via faker
 tomli==2.0.1
     # via django-stubs
 traitlets==5.9.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dev = [
     "pytest-httpx",
 
     "freezegun",
-    "mixer==7.0.6",
+    "mixer==7.2.2",
     "requests-mock",
 
     "black",

--- a/src/app/factory.py
+++ b/src/app/factory.py
@@ -1,20 +1,12 @@
-from io import BytesIO
-
-from PIL import Image
+from faker import Faker
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 
 from app.test.factory import register
 
+faker = Faker()
+
 
 @register
-def uploaded_image(self):
-    """
-    Can be used in both DRF API and mixer.
-    DRF won't let you use invalid image, so the content is a real image.
-    """
-    bytes_io = BytesIO()
-    Image.new("RGB", size=(10, 10), color=(0, 255, 255)).save(bytes_io, "GIF")
-    bytes_io.seek(0)
-    image_content = bytes_io.read()
-    return SimpleUploadedFile("image.gif", image_content, "image/gif")
+def image(self, name: str = "image.gif", content_type: str = "image/gif") -> SimpleUploadedFile:
+    return SimpleUploadedFile(name=name, content=faker.image(), content_type=content_type)

--- a/src/diplomas/tests/api/tests_diploma_create.py
+++ b/src/diplomas/tests/api/tests_diploma_create.py
@@ -23,7 +23,7 @@ def order(factory, course, student):
 
 @pytest.fixture
 def image(factory):
-    return factory.uploaded_image()
+    return factory.image()
 
 
 @pytest.fixture

--- a/src/diplomas/tests/api/tests_diploma_update_is_disabled.py
+++ b/src/diplomas/tests/api/tests_diploma_update_is_disabled.py
@@ -15,7 +15,7 @@ def test(api, factory, diploma):
     api.put(
         f"/api/v2/diplomas/{diploma.slug}/",
         {
-            "image": factory.uploaded_image(),
+            "image": factory.image(),
         },
         format="multipart",
         expected_status_code=405,

--- a/src/diplomas/tests/tests_diploma_regenerator.py
+++ b/src/diplomas/tests/tests_diploma_regenerator.py
@@ -13,7 +13,7 @@ pytestmark = [
 
 @pytest.fixture(autouse=True)
 def _mock_diploma_generator_fetch_image(mocker, factory):
-    image = factory.uploaded_image()
+    image = factory.image()
     mocker.patch("diplomas.services.diploma_regenerator.DiplomaGenerator.fetch_image", return_value=image)
 
 


### PR DESCRIPTION
Фикстура `uploaded_image` используется во всех проектах, в основе которых `django`-шаблон. Предлагаю её улучшить в соответствии с новинками последних версий `faker`.

>Can be used in both DRF API and mixer.
>DRF won't let you use invalid image, so the content is a real image.

Докстринг убрала тоже, потому что в запросах можно использовать `faker.image_url()`-функцию и DRF, по идее, этот вариант подойдёт: https://youtu.be/o67xQ9-usRU. 