### PR TITLE
Notion cache upd command

### DIFF
--- a/src/notion/cache.py
+++ b/src/notion/cache.py
@@ -70,4 +70,5 @@ def get_cached_page(page_id: str) -> NotionPage:
 
 __all__ = [
     "get_cached_page",
+    "cache",
 ]

--- a/src/notion/cache.py
+++ b/src/notion/cache.py
@@ -9,7 +9,7 @@ from notion.client import NotionClient
 from notion.models import NotionCacheEntry
 from notion.page import NotionPage
 
-TIMEOUT = 60 * 60 * 24 * 14  # 14 days
+TIMEOUT = 60 * 60 * 24 * 365 * 5  # 5 years
 
 
 class NotionCache:

--- a/src/notion/cache.py
+++ b/src/notion/cache.py
@@ -70,5 +70,4 @@ def get_cached_page(page_id: str) -> NotionPage:
 
 __all__ = [
     "get_cached_page",
-    "cache",
 ]

--- a/src/notion/management/commands/update_notion_cache.py
+++ b/src/notion/management/commands/update_notion_cache.py
@@ -1,0 +1,18 @@
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+from notion import tasks
+
+
+class Command(BaseCommand):
+    help = "Updates cache for all active Notion materials"
+
+    def handle(self, *args: Any, **options: dict[str, Any]) -> None:
+        confirm = input("Are you sure you want to update cache for all active Notion materials? (y/n): ")
+        if confirm.lower() not in ("y", "yes"):
+            self.stdout.write(self.style.WARNING("Cache update cancelled"))
+            return
+
+        tasks.update_cache_for_all_active_notion_materials.delay()
+        self.stdout.write(self.style.SUCCESS("Task for updating cache is made. Cache will be updated soon"))

--- a/src/notion/management/commands/update_notion_cache.py
+++ b/src/notion/management/commands/update_notion_cache.py
@@ -9,10 +9,5 @@ class Command(BaseCommand):
     help = "Updates cache for all active Notion materials"
 
     def handle(self, *args: Any, **options: dict[str, Any]) -> None:
-        confirm = input("Are you sure you want to update cache for all active Notion materials? (y/n): ")
-        if confirm.lower() not in ("y", "yes"):
-            self.stdout.write(self.style.WARNING("Cache update cancelled"))
-            return
-
         tasks.update_cache_for_all_active_notion_materials.delay()
         self.stdout.write(self.style.SUCCESS("Task for updating cache is made. Cache will be updated soon"))

--- a/src/notion/tasks.py
+++ b/src/notion/tasks.py
@@ -4,14 +4,14 @@ from notion.client import NotionClient
 from notion.models import Material
 
 
-@celery.task
-def update_cache_notion_material(page_id):
+@celery.task(rate_limit="6/m")
+def update_cache_notion_material(page_id: str) -> None:
     page = NotionClient().fetch_page_recursively(page_id)
     cache.set(page_id, page)
 
 
-@celery.task(rate_limit="6/m")
-def update_cache_for_all_active_notion_materials():
+@celery.task
+def update_cache_for_all_active_notion_materials() -> None:
     page_ids = Material.objects.active().values_list("page_id", flat=True).distinct()
     for page_id in page_ids:
         update_cache_notion_material.delay(page_id)

--- a/src/notion/tasks.py
+++ b/src/notion/tasks.py
@@ -10,7 +10,7 @@ def update_cache_notion_material(page_id):
     cache.set(page_id, page)
 
 
-@celery.task
+@celery.task(rate_limit="6/m")
 def update_cache_for_all_active_notion_materials():
     page_ids = Material.objects.active().values_list("page_id", flat=True).distinct()
     for page_id in page_ids:

--- a/src/notion/tasks.py
+++ b/src/notion/tasks.py
@@ -1,0 +1,17 @@
+from app.celery import celery
+from notion.cache import cache
+from notion.client import NotionClient
+from notion.models import Material
+
+
+@celery.task
+def update_cache_notion_material(page_id):
+    page = NotionClient().fetch_page_recursively(page_id)
+    cache.set(page_id, page)
+
+
+@celery.task
+def update_cache_for_all_active_notion_materials():
+    page_ids = Material.objects.active().values_list("page_id", flat=True).distinct()
+    for page_id in page_ids:
+        update_cache_notion_material.delay(page_id)

--- a/src/notion/tasks.py
+++ b/src/notion/tasks.py
@@ -4,7 +4,7 @@ from notion.client import NotionClient
 from notion.models import Material
 
 
-@celery.task(rate_limit="6/m")
+@celery.task(rate_limit="6/m", acks_late=True)
 def update_cache_notion_material(page_id: str) -> None:
     page = NotionClient().fetch_page_recursively(page_id)
     cache.set(page_id, page)

--- a/src/notion/tests/api/conftest.py
+++ b/src/notion/tests/api/conftest.py
@@ -15,11 +15,6 @@ def api(api):
 
 
 @pytest.fixture
-def course(mixer):
-    return mixer.blend("products.Course")
-
-
-@pytest.fixture
 def another_course(mixer):
     return mixer.blend("products.Course")
 

--- a/src/notion/tests/conftest.py
+++ b/src/notion/tests/conftest.py
@@ -5,6 +5,10 @@ from notion.block import NotionBlockList
 from notion.client import NotionClient
 from notion.page import NotionPage
 
+pytestmark = [
+    pytest.mark.django_db,
+]
+
 
 @pytest.fixture
 def notion() -> NotionClient:
@@ -35,4 +39,47 @@ def page() -> NotionPage:
                 NotionBlock(id="block-2", data={"role": "reader-2"}),
             ]
         )
+    )
+
+
+@pytest.fixture
+def page_as_dict(page):
+    first_block = page.blocks[0]
+    second_block = page.blocks[1]
+    return {
+        "blocks": [
+            {
+                "id": first_block.id,
+                "data": first_block.data,
+            },
+            {
+                "id": second_block.id,
+                "data": second_block.data,
+            },
+        ]
+    }
+
+
+@pytest.fixture
+def cache_entry(not_expired_datetime, page_as_dict, mixer):
+    return mixer.blend(
+        "notion.NotionCacheEntry",
+        cache_key="some_key",
+        content=page_as_dict,
+        expires=not_expired_datetime,
+    )
+
+
+@pytest.fixture
+def course(mixer):
+    return mixer.blend("products.Course")
+
+
+@pytest.fixture
+def material(mixer, course):
+    return mixer.blend(
+        "notion.Material",
+        course=course,
+        page_id="0e5693d2173a4f77ae8106813b6e5329",
+        slug="4d5726e8ee524448b8f97be4c7f8e632",
     )

--- a/src/notion/tests/test_celery_tasks.py
+++ b/src/notion/tests/test_celery_tasks.py
@@ -1,0 +1,39 @@
+import pytest
+
+from notion.tasks import update_cache_for_all_active_notion_materials
+from notion.tasks import update_cache_notion_material
+
+pytestmark = [
+    pytest.mark.django_db,
+]
+
+
+@pytest.fixture
+def mock_fetch_page_recursively(mocker, page):
+    return mocker.patch(
+        "notion.client.NotionClient.fetch_page_recursively",
+        return_value=page,
+    )
+
+
+@pytest.fixture
+def mock_cache_set(mocker):
+    return mocker.patch("notion.cache.NotionCache.set")
+
+
+def test_call_update_cache_notion_material(mock_fetch_page_recursively, mock_cache_set, material, page):
+    update_cache_notion_material(material.page_id)
+
+    mock_cache_set.assert_called_once_with(material.page_id, page)
+    mock_fetch_page_recursively.assert_called_once_with(material.page_id)
+
+
+def test_call_update_cache_for_all_active_notion_materials(mock_fetch_page_recursively, mock_cache_set, material, page, mixer):
+    for _ in range(3):
+        mixer.blend("notion.Material", active=False)
+        mixer.blend("notion.Material", active=True, page_id=material.page_id)
+
+    update_cache_for_all_active_notion_materials()
+
+    mock_cache_set.assert_called_once_with(material.page_id, page)
+    mock_fetch_page_recursively.assert_called_once_with(material.page_id)

--- a/src/notion/tests/test_fetch_page.py
+++ b/src/notion/tests/test_fetch_page.py
@@ -5,6 +5,10 @@ from pytest_httpx import HTTPXMock
 from notion.exceptions import NotionResponseError
 from notion.exceptions import NotSharedForWeb
 
+pytestmark = [
+    pytest.mark.django_db,
+]
+
 
 @pytest.fixture()
 def ok():

--- a/src/notion/tests/test_notion_cache.py
+++ b/src/notion/tests/test_notion_cache.py
@@ -21,24 +21,6 @@ def cache():
 
 
 @pytest.fixture
-def page_as_dict(page):
-    first_block = page.blocks[0]
-    second_block = page.blocks[1]
-    return {
-        "blocks": [
-            {
-                "id": first_block.id,
-                "data": first_block.data,
-            },
-            {
-                "id": second_block.id,
-                "data": second_block.data,
-            },
-        ]
-    }
-
-
-@pytest.fixture
 def another_page() -> NotionPage:
     return NotionPage(
         blocks=NotionBlockList(
@@ -62,16 +44,6 @@ def not_expired_datetime():
 @pytest.fixture
 def expired_datetime():
     return timezone.now()
-
-
-@pytest.fixture
-def cache_entry(not_expired_datetime, page_as_dict, mixer):
-    return mixer.blend(
-        "notion.NotionCacheEntry",
-        cache_key="some_key",
-        content=page_as_dict,
-        expires=not_expired_datetime,
-    )
 
 
 @pytest.fixture


### PR DESCRIPTION
По мотивам https://github.com/tough-dev-school/education-backend/pull/1695#issuecomment-1607415567

Добавил команду update_notion_cache и поднял TIMEOUT до 5 лет

Команда закидывает в очередь celery таски по апдейту кеша для всех _уникальных и активных_ страниц