### PR TITLE
notion always from cache if possible with env var

### DIFF
--- a/src/app/conf/integrations/notion.py
+++ b/src/app/conf/integrations/notion.py
@@ -2,3 +2,4 @@ from app.conf.environ import env
 
 NOTION_MIDDLEWARE_URL = env("NOTION_MIDDLEWARE_URL", cast=str, default="")
 NOTION_MIDDLEWARE_TIMEOUT = env("NOTION_MIDDLEWARE_TIMEOUT", cast=int, default=15)
+NOTION_CACHE_ONLY = env("NOTION_CACHE_ONLY", cast=bool, default=False)

--- a/src/notion/cache.py
+++ b/src/notion/cache.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from datetime import timedelta
 from typing import Callable
 
+from django.conf import settings
 from django.utils import timezone
 
 from app.current_user import get_current_user
@@ -52,6 +53,8 @@ def fetch_page(page_id: str) -> Callable[[], NotionPage]:
 
 
 def cache_disabled() -> bool:
+    if settings.NOTION_CACHE_ONLY:
+        return False
     user = get_current_user()
     if user:
         return user.is_staff

--- a/src/notion/cache.py
+++ b/src/notion/cache.py
@@ -52,9 +52,10 @@ def fetch_page(page_id: str) -> Callable[[], NotionPage]:
     return lambda: NotionClient().fetch_page_recursively(page_id)
 
 
-def cache_disabled() -> bool:
+def should_bypass_cache() -> bool:
     if settings.NOTION_CACHE_ONLY:
         return False
+
     user = get_current_user()
     if user:
         return user.is_staff
@@ -63,7 +64,7 @@ def cache_disabled() -> bool:
 
 
 def get_cached_page(page_id: str) -> NotionPage:
-    if cache_disabled():
+    if should_bypass_cache():
         page = fetch_page(page_id)()
         cache.set(page_id, page)
         return page

--- a/src/notion/tests/api/conftest.py
+++ b/src/notion/tests/api/conftest.py
@@ -47,4 +47,4 @@ def mock_notion_response(mocker, page: NotionPage):
 
 @pytest.fixture
 def _disable_notion_cache(mocker):
-    mocker.patch("notion.cache.cache_disabled", return_value=True)
+    mocker.patch("notion.cache.should_bypass_cache", return_value=True)

--- a/src/notion/tests/api/test_notion_cache_api.py
+++ b/src/notion/tests/api/test_notion_cache_api.py
@@ -12,12 +12,8 @@ pytestmark = [
 
 
 @pytest.fixture
-def as_staff(mixer):
-    user = mixer.blend("users.User", is_superuser=False, is_staff=True)
-
-    user.add_perm("notion.material.see_all_materials")
-
-    return DRFClient(user=user)
+def as_staff(staff_user):
+    return DRFClient(user=staff_user)
 
 
 @pytest.fixture

--- a/src/notion/tests/conftest.py
+++ b/src/notion/tests/conftest.py
@@ -11,6 +11,14 @@ pytestmark = [
 
 
 @pytest.fixture
+def staff_user(mixer):
+    user = mixer.blend("users.User", is_superuser=False, is_staff=True)
+    user.add_perm("notion.material.see_all_materials")
+
+    return user
+
+
+@pytest.fixture
 def notion() -> NotionClient:
     return NotionClient()
 

--- a/src/notion/tests/test_notion_cache.py
+++ b/src/notion/tests/test_notion_cache.py
@@ -137,9 +137,8 @@ def test_get_or_set_set_if_doesnt_exist(cache, another_page):
 def test_user_always_gets_page_from_existing_cache(settings, cache_entry, env_value, mock_cache_set, mock_fetch_page):
     settings.NOTION_CACHE_ONLY = bool(env_value)
 
-    got = get_cached_page(cache_entry.cache_key)
+    get_cached_page(cache_entry.cache_key)
 
-    assert got == NotionPage.from_json(cache_entry.content)
     mock_cache_set.assert_not_called()
     mock_fetch_page.assert_not_called()
 
@@ -148,9 +147,8 @@ def test_user_always_gets_page_from_existing_cache(settings, cache_entry, env_va
 def test_staff_user_get_page_from_cache_if_env_cache(settings, cache_entry, mock_cache_set, mock_fetch_page):
     settings.NOTION_CACHE_ONLY = bool("On")
 
-    got = get_cached_page(cache_entry.cache_key)
+    get_cached_page(cache_entry.cache_key)
 
-    assert got == NotionPage.from_json(cache_entry.content)
     mock_cache_set.assert_not_called()
     mock_fetch_page.assert_not_called()
 

--- a/src/notion/tests/test_notion_cache.py
+++ b/src/notion/tests/test_notion_cache.py
@@ -134,7 +134,7 @@ def test_get_or_set_set_if_doesnt_exist(cache, another_page):
 
 @pytest.mark.parametrize("env_value", ["On", ""])
 @pytest.mark.usefixtures("current_user_casual")
-def test_user_get_page_from_existing_cache_always(settings, cache_entry, env_value, mock_cache_set, mock_fetch_page):
+def test_user_always_gets_page_from_existing_cache(settings, cache_entry, env_value, mock_cache_set, mock_fetch_page):
     settings.NOTION_CACHE_ONLY = bool(env_value)
 
     got = get_cached_page(cache_entry.cache_key)


### PR DESCRIPTION
Чтобы локально можно было включить кеш ноушена по умолчанию - добавил опциональную переменную NOTION_CACHE_ONLY.

Теперь все что потребуется - добавить в docker-compose локальный NOTION_CACHE_ONLY=On

В ноушен пойдем только в том случае, если в кеше страницы нет совсем