### PR TITLE
add ya to yandex converter

### DIFF
--- a/src/app/integrations/dashamail/client.py
+++ b/src/app/integrations/dashamail/client.py
@@ -30,6 +30,9 @@ class AppDashamail:
 
     def get_subscriber(self, email: str) -> tuple[int | None, bool]:
         """Return tuple which consists of member_id and is_active"""
+        if "@ya.ru" in email:
+            # Dashamail internally convert ya.ru to yandex.ru, with ya.ru we're going to get nothing
+            email = email.replace("@ya.ru", "@yandex.ru")
 
         payload = {
             "method": "lists.get_members",

--- a/src/app/integrations/dashamail/client.py
+++ b/src/app/integrations/dashamail/client.py
@@ -30,7 +30,7 @@ class AppDashamail:
 
     def get_subscriber(self, email: str) -> tuple[int | None, bool]:
         """Return tuple which consists of member_id and is_active"""
-        if "@ya.ru" in email:
+        if email.endswith("@ya.ru"):
             # Dashamail internally convert ya.ru to yandex.ru, with ya.ru we're going to get nothing
             email = email.replace("@ya.ru", "@yandex.ru")
 

--- a/src/app/tests/dashamail/tests_dashamail_get_subscriber.py
+++ b/src/app/tests/dashamail/tests_dashamail_get_subscriber.py
@@ -27,6 +27,21 @@ def test_get_subscriber(dashamail, post, user):
     )
 
 
+@pytest.mark.parametrize(("email", "expected_email"), [("hehe@ya.ru", "hehe@yandex.ru"), ("simple@yandex.ru", "simple@yandex.ru")])
+def test_get_subscriber_with_yandex_mail(dashamail, post, user, email, expected_email):
+    user.email = email
+    user.save()
+
+    dashamail.get_subscriber(
+        email=user.email,
+    )
+
+    post.assert_called_once_with(
+        url="",
+        payload={"email": expected_email, "list_id": "1", "method": "lists.get_members"},
+    )
+
+
 def test_get_subscriber_correct_values(dashamail, user, successful_response_json):
     dashamail.httpx_mock.add_response(url="https://api.dashamail.com", method="POST", json=successful_response_json)
 


### PR DESCRIPTION
Обнаружил незадокументрированную особенность dashamail - она сохраняет все email с доменом @ya.ru как @yandex.ru. Из-за этого у нас клиент даши не может найти сохраненного пользователя.

С этим фиксом база будет корректно обновляться 