### PR TITLE
upd or del answer only if no child or created lte a day

### DIFF
--- a/src/homework/api/permissions.py
+++ b/src/homework/api/permissions.py
@@ -53,9 +53,18 @@ class MayChangeAnswerOnlyForLimitedTime(permissions.BasePermission):
         if request.method in permissions.SAFE_METHODS:
             return True
 
-        last_update_time = obj.created if obj.modified is None else obj.modified
+        if timezone.now() - obj.created < timedelta(days=1):
+            return True
 
-        if timezone.now() - last_update_time < timedelta(minutes=30):
+        return False
+
+
+class MayChangeAnswerOnlyWithoutDescendants(permissions.BasePermission):
+    def has_object_permission(self, request: Request, view: APIView, obj: Any) -> bool:
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
+        if obj.get_first_level_descendants().count() == 0:
             return True
 
         return False

--- a/src/homework/api/viewsets.py
+++ b/src/homework/api/viewsets.py
@@ -15,6 +15,7 @@ from app.viewsets import AppViewSet
 from app.viewsets import CreateDeleteAppViewSet
 from homework.api.filtersets import AnswerFilterSet
 from homework.api.permissions import MayChangeAnswerOnlyForLimitedTime
+from homework.api.permissions import MayChangeAnswerOnlyWithoutDescendants
 from homework.api.permissions import ShouldBeAuthorOrReadOnly
 from homework.api.permissions import ShouldHavePurchasedQuestionCoursePermission
 from homework.api.serializers import AnswerCreateSerializer
@@ -38,7 +39,11 @@ class AnswerViewSet(DisablePaginationWithQueryParamMixin, AppViewSet):
 
     lookup_field = "slug"
     permission_classes = [
-        IsAuthenticated & ShouldHavePurchasedQuestionCoursePermission & ShouldBeAuthorOrReadOnly & MayChangeAnswerOnlyForLimitedTime,
+        IsAuthenticated
+        & ShouldHavePurchasedQuestionCoursePermission
+        & ShouldBeAuthorOrReadOnly
+        & MayChangeAnswerOnlyForLimitedTime
+        & MayChangeAnswerOnlyWithoutDescendants,
     ]
     filterset_class = AnswerFilterSet
 

--- a/src/homework/tests/api/conftest.py
+++ b/src/homework/tests/api/conftest.py
@@ -39,6 +39,11 @@ def another_answer(mixer, question, api):
 
 
 @pytest.fixture
+def child_answer(answer, mixer):
+    return mixer.blend("homework.Answer", parent=answer)
+
+
+@pytest.fixture
 def purchase(factory, course, api):
     order = factory.order(user=api.user, item=course)
     order.set_paid()

--- a/src/homework/tests/api/tests_answer_destroy.py
+++ b/src/homework/tests/api/tests_answer_destroy.py
@@ -21,7 +21,7 @@ def test_ok(api, answer):
         answer.refresh_from_db()
 
 
-def test_destory_non_root_answer(api, answer, answer_of_another_author):
+def test_destroy_non_root_answer(api, answer, answer_of_another_author):
     answer.parent = answer_of_another_author
     answer.save()
 
@@ -31,16 +31,21 @@ def test_destory_non_root_answer(api, answer, answer_of_another_author):
         answer.refresh_from_db()
 
 
-def test_only_answers_not_longer_then_30_minutes_may_be_destroyed(api, answer, freezer):
-    freezer.move_to("2032-12-01 16:30")
+@pytest.mark.usefixtures("child_answer")
+def test_only_answers_without_descendants_may_be_destroyed(api, answer):
+    api.delete(f"/api/v2/homework/answers/{answer.slug}/", expected_status_code=403)
+
+
+def test_only_answers_not_longer_than_a_day_may_be_destroyed(api, answer, freezer):
+    freezer.move_to("2032-12-02 15:30")
 
     api.delete(f"/api/v2/homework/answers/{answer.slug}/", expected_status_code=403)
 
 
-def test_answers_modified_within_last_30_minutes_may_be_destroyed(api, answer, freezer):
-    freezer.move_to("2032-12-01 16:30+05:00")
+def test_answers_created_within_a_day_may_be_destroyed(api, answer, freezer):
+    freezer.move_to("2032-12-02 16:20+05:00")
 
-    Answer.objects.update(modified="2032-12-01 16:24+05:00")
+    Answer.objects.update(created="2032-12-01 16:24+05:00")
 
     api.delete(f"/api/v2/homework/answers/{answer.slug}/", expected_status_code=204)
 

--- a/src/homework/tests/api/tests_answer_destroy.py
+++ b/src/homework/tests/api/tests_answer_destroy.py
@@ -33,6 +33,8 @@ def test_destroy_non_root_answer(api, answer, answer_of_another_author):
 
 @pytest.mark.usefixtures("child_answer")
 def test_only_answers_without_descendants_may_be_destroyed(api, answer):
+    Answer.objects.update(created="2032-12-01 15:30:12+03:00")
+
     api.delete(f"/api/v2/homework/answers/{answer.slug}/", expected_status_code=403)
 
 

--- a/src/homework/tests/api/tests_answer_update.py
+++ b/src/homework/tests/api/tests_answer_update.py
@@ -85,6 +85,8 @@ def test_answers_created_within_a_day_may_be_updated(api, answer, freezer):
 
 @pytest.mark.usefixtures("child_answer")
 def test_only_answers_without_descendants_may_be_edited(api, answer):
+    Answer.objects.update(created="2032-12-01 15:30:12+03:00")
+
     api.patch(f"/api/v2/homework/answers/{answer.slug}/", {"text": "*patched*"}, expected_status_code=403)
 
 

--- a/src/homework/tests/api/tests_answer_update.py
+++ b/src/homework/tests/api/tests_answer_update.py
@@ -69,18 +69,23 @@ def test_405_for_put(api, answer):
     api.put(f"/api/v2/homework/answers/{answer.slug}/", {"text": "*patched*"}, expected_status_code=405)
 
 
-def test_only_answers_not_longer_then_30_minutes_may_be_edited(api, answer, freezer):
-    freezer.move_to("2032-12-01 16:30+03:00")
+def test_only_answers_not_longer_than_a_day_may_be_edited(api, answer, freezer):
+    freezer.move_to("2032-12-02 16:30+03:00")
 
     api.patch(f"/api/v2/homework/answers/{answer.slug}/", {"text": "*patched*"}, expected_status_code=403)
 
 
-def test_answers_modified_within_last_30_minutes_may_be_updated(api, answer, freezer):
-    freezer.move_to("2032-12-01 16:30+03:00")
+def test_answers_created_within_a_day_may_be_updated(api, answer, freezer):
+    freezer.move_to("2032-12-02 16:20+03:00")
 
-    Answer.objects.update(modified="2032-12-01 16:24+03:00")
+    Answer.objects.update(created="2032-12-01 16:24+03:00")
 
     api.patch(f"/api/v2/homework/answers/{answer.slug}/", {"text": "*patched*"}, expected_status_code=200)
+
+
+@pytest.mark.usefixtures("child_answer")
+def test_only_answers_without_descendants_may_be_edited(api, answer):
+    api.patch(f"/api/v2/homework/answers/{answer.slug}/", {"text": "*patched*"}, expected_status_code=403)
 
 
 @pytest.mark.xfail(reason="WIP: will add per-course permissions later")


### PR DESCRIPTION
К [задаче](https://3.basecamp.com/5104612/buckets/29069198/todos/6138331082) 

Поменял немного логику MayChangeAnswerOnlyForLimitedTime - теперь ровно сутки с момента создания ответа, а не полчаса с последнего изменения (было бы странно продлевать на сутки от каждого апдейта, на мой взгляд)

Добавил MayChangeAnswerOnlyWithoutDescendants - проверяет, есть ли дочерние ответы у текущего. 