### PR TITLE
add has_descendants field to comments list view

### DIFF
--- a/src/homework/api/serializers.py
+++ b/src/homework/api/serializers.py
@@ -85,11 +85,12 @@ class AnswerTreeSerializer(AnswerDetailedSerializer):
             "text",
             "src",
             "descendants",
+            "has_descendants",
             "reactions",
         ]
 
     def get_descendants(self, obj: Answer) -> list[dict]:
-        queryset = obj.get_first_level_descendants().select_related("question", "author").prefetch_reactions()
+        queryset = obj.get_first_level_descendants().with_children_count().select_related("question", "author").prefetch_reactions()
         serializer = AnswerTreeSerializer(
             queryset,
             many=True,

--- a/src/homework/api/views.py
+++ b/src/homework/api/views.py
@@ -19,7 +19,7 @@ class QuestionView(generics.RetrieveAPIView):
 
 
 class AnswerCommentView(generics.ListAPIView):
-    queryset = Answer.objects.for_viewset()
+    queryset = Answer.objects.for_viewset().with_children_count()
     serializer_class = serializers.AnswerCommentTreeSerializer
     filterset_class = AnswerCommentFilterSet
     permission_classes = [IsAuthenticated]

--- a/src/homework/api/views.py
+++ b/src/homework/api/views.py
@@ -19,7 +19,7 @@ class QuestionView(generics.RetrieveAPIView):
 
 
 class AnswerCommentView(generics.ListAPIView):
-    queryset = Answer.objects.for_viewset().with_children_count()
+    queryset = Answer.objects.for_viewset()
     serializer_class = serializers.AnswerCommentTreeSerializer
     filterset_class = AnswerCommentFilterSet
     permission_classes = [IsAuthenticated]

--- a/src/homework/tests/api/tests_comments_list_descendants.py
+++ b/src/homework/tests/api/tests_comments_list_descendants.py
@@ -60,7 +60,7 @@ def test_child_answers_fields(get_answer_comments, answer, another_answer, anoth
     got = get_answer_comments()[0]
 
     descendant = got["descendants"][0]
-    assert len(descendant) == 10
+    assert len(descendant) == 11
     assert descendant["created"] == "2022-10-09T10:30:12+12:00"
     assert descendant["modified"] == "2022-10-09T10:30:12+12:00"
     assert descendant["slug"] == str(another_answer.slug)
@@ -69,6 +69,7 @@ def test_child_answers_fields(get_answer_comments, answer, another_answer, anoth
     assert descendant["author"]["uuid"] == str(another_answer.author.uuid)
     assert descendant["author"]["first_name"] == another_answer.author.first_name
     assert descendant["author"]["last_name"] == another_answer.author.last_name
+    assert "has_descendants" in descendant
     assert "text" in descendant
     assert "src" in descendant
     assert "descendants" in descendant


### PR DESCRIPTION
Добавил поле has_descendants [по запросу Тимура](https://3.basecamp.com/5104612/buckets/29069198/todos/6138331082#__recording_6371551145) чтобы у ответа и комментариев была одинаковая схема.

Тесты целы, н+1 не добавилось