### PR TITLE
Set correct timeouts for amocrm caches

### DIFF
--- a/src/amocrm/cache/catalog_id.py
+++ b/src/amocrm/cache/catalog_id.py
@@ -21,7 +21,7 @@ def get_catalog_id_amocrm(catalog_type: CATALOG_TYPES) -> int:
 
 def get_catalog_id(catalog_type: CATALOG_TYPES) -> int:
     cache_key = CATALOGS_TO_CACHE[catalog_type]
-    return cache.get_or_set(cache_key, lambda: get_catalog_id_amocrm(catalog_type))  # type: ignore
+    return cache.get_or_set(cache_key, lambda: get_catalog_id_amocrm(catalog_type), timeout=None)  # type: ignore
 
 
 __all__ = ["get_catalog_id"]

--- a/src/amocrm/cache/product_fields_ids.py
+++ b/src/amocrm/cache/product_fields_ids.py
@@ -31,7 +31,7 @@ def get_field_id_from_amocrm(field_code: FIELDS_CODES) -> int:
 
 def get_product_field_id(field_code: FIELDS_CODES) -> int:
     cache_key = FIELDS_TO_CACHE[field_code]
-    return cache.get_or_set(cache_key, lambda: get_field_id_from_amocrm(field_code))  # type: ignore
+    return cache.get_or_set(cache_key, lambda: get_field_id_from_amocrm(field_code), timeout=None)  # type: ignore
 
 
 __all__ = ["get_product_field_id"]

--- a/src/amocrm/services/access_token_getter.py
+++ b/src/amocrm/services/access_token_getter.py
@@ -67,8 +67,9 @@ class AmoCRMTokenGetter(BaseService):
     @staticmethod
     def save_tokens(data: dict) -> str:
         timeout = int(data["expires_in"]) - 60 * 5  # remove token 5 min before expiration time
+        refresh_token_timeout = 60 * 60 * 24 * 30  # refresh token lives till first usage or 30 days
         cache.set("amocrm_access_token", data["access_token"], timeout=timeout)
-        cache.set("amocrm_refresh_token", data["refresh_token"])
+        cache.set("amocrm_refresh_token", data["refresh_token"], timeout=refresh_token_timeout)
         return data["access_token"]
 
     @staticmethod


### PR DESCRIPTION
Поставил вечный срок для кешей с id
И 30 дней для refresh_token, тк столько он и живет, а дефолтные 5 минут слишком мало