### PR TITLE
Fix client amocrm and add return values to tasks

### DIFF
--- a/src/amocrm/cache/catalog_id.py
+++ b/src/amocrm/cache/catalog_id.py
@@ -2,6 +2,7 @@ from typing import Literal
 
 from django.core.cache import cache
 
+from amocrm.client import AmoCRMClient
 from amocrm.exceptions import AmoCRMCacheException
 
 CATALOG_TYPES = Literal["products"]
@@ -9,8 +10,6 @@ CATALOGS_TO_CACHE = {"products": "amocrm_products_catalog_id"}
 
 
 def get_catalog_id_amocrm(catalog_type: CATALOG_TYPES) -> int:
-    from amocrm.client import AmoCRMClient
-
     client = AmoCRMClient()
     catalogs = [catalog for catalog in client.get_catalogs() if catalog.type == catalog_type]
     if len(catalogs) != 1:

--- a/src/amocrm/cache/product_fields_ids.py
+++ b/src/amocrm/cache/product_fields_ids.py
@@ -3,6 +3,7 @@ import typing
 from django.core.cache import cache
 
 from amocrm.cache.catalog_id import get_catalog_id
+from amocrm.client import AmoCRMClient
 from amocrm.exceptions import AmoCRMCacheException
 
 FIELDS_CODES = typing.Literal["SKU", "PRICE", "SPECIAL_PRICE_1", "GROUP", "DESCRIPTION", "EXTERNAL_ID"]
@@ -17,8 +18,6 @@ FIELDS_TO_CACHE = {
 
 
 def get_field_id_from_amocrm(field_code: FIELDS_CODES) -> int:
-    from amocrm.client import AmoCRMClient
-
     client = AmoCRMClient()
     product_catalog_id = get_catalog_id(catalog_type="products")
 

--- a/src/amocrm/client/client.py
+++ b/src/amocrm/client/client.py
@@ -40,7 +40,7 @@ class AmoCRMClient:
     def get_catalogs(self) -> list[AmoCRMCatalog]:
         """Returns all catalogs from amocrm"""
         response = self.http.get(url="/api/v4/catalogs", params={"limit": 250})  # request max amount of catalogs
-        return [AmoCRMCatalog.from_json(catalog) for catalog in response["_embedded"]["items"]]
+        return [AmoCRMCatalog.from_json(catalog) for catalog in response["_embedded"]["catalogs"]]
 
     def get_catalog_fields(self, catalog_id: int) -> list[AmoCRMCatalogField]:
         """Returns chosen catalog's fields"""

--- a/src/amocrm/client/http.py
+++ b/src/amocrm/client/http.py
@@ -6,11 +6,12 @@ from httpx import Response
 
 from django.conf import settings
 
+from amocrm.exceptions import AmoCRMException
 from amocrm.services.access_token_getter import AmoCRMTokenGetter
 
 
-class AmoCRMClientException(Exception):
-    pass
+class AmoCRMClientException(AmoCRMException):
+    """Raises when client cannot make successful request"""
 
 
 class AmoCRMHTTP:

--- a/src/amocrm/exceptions.py
+++ b/src/amocrm/exceptions.py
@@ -16,4 +16,5 @@ class AmoCRMServiceException(AppServiceException, AmoCRMException):
 __all__ = [
     "AmoCRMCacheException",
     "AmoCRMServiceException",
+    "AmoCRMException",
 ]

--- a/src/amocrm/services/course_creator.py
+++ b/src/amocrm/services/course_creator.py
@@ -21,6 +21,7 @@ class AmoCRMCourseCreatorException(AmoCRMServiceException):
 class AmoCRMCourseCreator(BaseService):
     """
     Creates course as element of products catalog in amocrm
+    Returns id of created AmoCRM product catalog entity
     """
 
     course: Course
@@ -28,7 +29,7 @@ class AmoCRMCourseCreator(BaseService):
     def __post_init__(self) -> None:
         self.client = AmoCRMClient()
 
-    def act(self) -> None:
+    def act(self) -> int:
         course_as_element = AmoCRMCatalogElement(
             name=self.course.name,
             custom_fields_values=self.get_fields_values(),
@@ -39,7 +40,8 @@ class AmoCRMCourseCreator(BaseService):
             element=course_as_element,
         )
 
-        AmoCRMCourse.objects.create(course=self.course, amocrm_id=element_with_amocrm_id.id)  # type: ignore
+        amocrm_course = AmoCRMCourse.objects.create(course=self.course, amocrm_id=element_with_amocrm_id.id)  # type: ignore
+        return amocrm_course.amocrm_id
 
     def get_fields_values(self) -> list[AmoCRMCatalogElementField]:
         price_field = AmoCRMCatalogElementField(

--- a/src/amocrm/services/course_updater.py
+++ b/src/amocrm/services/course_updater.py
@@ -19,6 +19,7 @@ class AmoCRMCourseUpdaterException(AmoCRMServiceException):
 class AmoCRMCourseUpdater(BaseService):
     """
     Updates course as element of products catalog in amocrm
+    Returns id of updated AmoCRM product catalog entity
     """
 
     amocrm_course: AmoCRMCourse
@@ -27,7 +28,7 @@ class AmoCRMCourseUpdater(BaseService):
         self.client = AmoCRMClient()
         self.course = self.amocrm_course.course
 
-    def act(self) -> None:
+    def act(self) -> int:
         course_as_element = AmoCRMCatalogElement(
             id=self.amocrm_course.amocrm_id,
             name=self.course.name,
@@ -38,6 +39,8 @@ class AmoCRMCourseUpdater(BaseService):
             catalog_id=self.product_catalog_id,
             element=course_as_element,
         )
+
+        return self.amocrm_course.amocrm_id
 
     def get_fields_values(self) -> list[AmoCRMCatalogElementField]:
         price_field = AmoCRMCatalogElementField(

--- a/src/amocrm/tasks.py
+++ b/src/amocrm/tasks.py
@@ -40,14 +40,15 @@ def enable_customers() -> None:
     rate_limit="3/s",
     acks_late=True,
 )
-def push_customer(user_id: int) -> None:
+def push_customer(user_id: int) -> int:
     client = AmoCRMClient()
     user = apps.get_model("users.User").objects.get(id=user_id)
     if hasattr(user, "amocrm_user"):
-        client.update_customer(amocrm_user=user.amocrm_user)
+        return client.update_customer(amocrm_user=user.amocrm_user)
     else:
         amocrm_id = client.create_customer(user=user)
-        AmoCRMUser.objects.create(user=user, amocrm_id=amocrm_id)
+        amocrm_user = AmoCRMUser.objects.create(user=user, amocrm_id=amocrm_id)
+        return amocrm_user.amocrm_id
 
 
 @celery.task(

--- a/src/amocrm/tasks.py
+++ b/src/amocrm/tasks.py
@@ -72,9 +72,9 @@ def push_product_groups() -> None:
     rate_limit="3/s",
     acks_late=True,
 )
-def push_course(course_id: int) -> None:
+def push_course(course_id: int) -> int:
     course = apps.get_model("products.Course").objects.get(id=course_id)
     if hasattr(course, "amocrm_course"):
-        AmoCRMCourseUpdater(amocrm_course=course.amocrm_course)()
+        return AmoCRMCourseUpdater(amocrm_course=course.amocrm_course)()
     else:
-        AmoCRMCourseCreator(course=course)()
+        return AmoCRMCourseCreator(course=course)()

--- a/src/amocrm/tests/course_services/tests_course_creator.py
+++ b/src/amocrm/tests/course_services/tests_course_creator.py
@@ -33,9 +33,10 @@ def course_creator():
 
 
 def test_creates_amocrm_course(course_creator, course):
-    course_creator(course)
+    got = course_creator(course)
 
     amocrm_course = AmoCRMCourse.objects.get()
+    assert got == amocrm_course.amocrm_id
     assert amocrm_course.course == course
     assert amocrm_course.amocrm_id == 999
 

--- a/src/amocrm/tests/course_services/tests_course_updater.py
+++ b/src/amocrm/tests/course_services/tests_course_updater.py
@@ -42,3 +42,10 @@ def test_updates_correct_call(course_updater, amocrm_course, mock_update_catalog
         catalog_id=777,
         element=updated_element,
     )
+
+
+@pytest.mark.usefixtures("mock_update_catalog_element")
+def test_update_amocrm_course(course_updater, amocrm_course):
+    got = course_updater(amocrm_course)
+
+    assert got == amocrm_course.amocrm_id

--- a/src/amocrm/tests/http/tests_create_catalog_element.py
+++ b/src/amocrm/tests/http/tests_create_catalog_element.py
@@ -26,8 +26,8 @@ def _successful_response(post):
                     "is_deleted": None,
                     "custom_fields_values": [
                         {"field_id": 2235143, "field_name": "Артикул", "field_code": "SKU", "field_type": "text", "values": [{"value": "not-hehe"}]},
-                        {"field_id": 2235147, "field_name": "Цена", "field_code": "PRICE", "field_type": "price", "values": [{"value": 999.12}]},
-                        {"field_id": 2235151, "field_name": "External ID", "field_code": "EXTERNAL_ID", "field_type": "text", "values": [{"value": 333}]},
+                        {"field_id": 2235147, "field_name": "Цена", "field_code": "PRICE", "field_type": "price", "values": [{"value": "999.12"}]},
+                        {"field_id": 2235151, "field_name": "External ID", "field_code": "EXTERNAL_ID", "field_type": "text", "values": [{"value": "333"}]},
                     ],
                     "catalog_id": 11271,
                     "account_id": 31204626,
@@ -60,7 +60,15 @@ def element(element_fields):
 def test_create_catalog_element(user, amocrm_client, element, element_fields):
     got = amocrm_client.create_catalog_element(catalog_id=777, element=element)
 
-    assert got == AmoCRMCatalogElement(id=14229449, name="PopugFields", custom_fields_values=element_fields)
+    assert got == AmoCRMCatalogElement(
+        id=14229449,
+        name="PopugFields",
+        custom_fields_values=[
+            AmoCRMCatalogElementField(field_id=2235143, values=[AmoCRMCatalogElementFieldValue(value="not-hehe")]),
+            AmoCRMCatalogElementField(field_id=2235147, values=[AmoCRMCatalogElementFieldValue(value="999.12")]),
+            AmoCRMCatalogElementField(field_id=2235151, values=[AmoCRMCatalogElementFieldValue(value="333")]),
+        ],
+    )
 
 
 @pytest.mark.usefixtures("_successful_response")
@@ -74,8 +82,8 @@ def test_create_catalog_element_post_correct_params(user, amocrm_client, post, e
                 "name": "PopugFields",
                 "custom_fields_values": [
                     {"field_id": 2235143, "values": [{"value": "not-hehe"}]},
-                    {"field_id": 2235147, "values": [{"value": 999.12}]},
-                    {"field_id": 2235151, "values": [{"value": 333}]},
+                    {"field_id": 2235147, "values": [{"value": "999.12"}]},
+                    {"field_id": 2235151, "values": [{"value": "333"}]},
                 ],
             },
         ],

--- a/src/amocrm/tests/http/tests_get_catalogs.py
+++ b/src/amocrm/tests/http/tests_get_catalogs.py
@@ -11,7 +11,7 @@ pytestmark = [
 @pytest.fixture
 def _successful_response(get):
     get.return_value = {
-        "_links": {"self": {"href": "/api/v2/catalogs", "method": "get"}},
+        "_links": {"self": {"href": "/api/v4/catalogs", "method": "get"}},
         "_embedded": {
             "catalogs": [
                 {
@@ -26,7 +26,7 @@ def _successful_response(get):
                     "can_link_multiple": True,
                     "sdk_widget_code": None,
                     "widgets": [],
-                    "_links": {"self": {"href": "/api/v2/catalogs?id=11271", "method": "get"}},
+                    "_links": {"self": {"href": "/api/v4/catalogs?id=11271", "method": "get"}},
                 },
                 {
                     "id": 11273,
@@ -40,7 +40,7 @@ def _successful_response(get):
                     "can_link_multiple": True,
                     "sdk_widget_code": None,
                     "widgets": [],
-                    "_links": {"self": {"href": "/api/v2/catalogs?id=11273", "method": "get"}},
+                    "_links": {"self": {"href": "/api/v4/catalogs?id=11273", "method": "get"}},
                 },
             ]
         },

--- a/src/amocrm/tests/http/tests_get_catalogs.py
+++ b/src/amocrm/tests/http/tests_get_catalogs.py
@@ -13,7 +13,7 @@ def _successful_response(get):
     get.return_value = {
         "_links": {"self": {"href": "/api/v2/catalogs", "method": "get"}},
         "_embedded": {
-            "items": [
+            "catalogs": [
                 {
                     "id": 11271,
                     "name": "Товары",

--- a/src/amocrm/tests/http/tests_update_catalog_element.py
+++ b/src/amocrm/tests/http/tests_update_catalog_element.py
@@ -26,8 +26,8 @@ def _successful_response(patch):
                     "is_deleted": None,
                     "custom_fields_values": [
                         {"field_id": 2235143, "field_name": "Артикул", "field_code": "SKU", "field_type": "text", "values": [{"value": "not-hehe"}]},
-                        {"field_id": 2235147, "field_name": "Цена", "field_code": "PRICE", "field_type": "price", "values": [{"value": 999.12}]},
-                        {"field_id": 2235151, "field_name": "External ID", "field_code": "EXTERNAL_ID", "field_type": "text", "values": [{"value": 333}]},
+                        {"field_id": 2235147, "field_name": "Цена", "field_code": "PRICE", "field_type": "price", "values": [{"value": "999.12"}]},
+                        {"field_id": 2235151, "field_name": "External ID", "field_code": "EXTERNAL_ID", "field_type": "text", "values": [{"value": "333"}]},
                     ],
                     "catalog_id": 11271,
                     "account_id": 31204626,
@@ -60,7 +60,15 @@ def element(element_fields):
 def test_update_catalog_element(user, amocrm_client, element, element_fields):
     got = amocrm_client.update_catalog_element(catalog_id=777, element=element)
 
-    assert got == AmoCRMCatalogElement(id=14229449, name="PopugFields", custom_fields_values=element_fields)
+    assert got == AmoCRMCatalogElement(
+        id=14229449,
+        name="PopugFields",
+        custom_fields_values=[
+            AmoCRMCatalogElementField(field_id=2235143, values=[AmoCRMCatalogElementFieldValue(value="not-hehe")]),
+            AmoCRMCatalogElementField(field_id=2235147, values=[AmoCRMCatalogElementFieldValue(value="999.12")]),
+            AmoCRMCatalogElementField(field_id=2235151, values=[AmoCRMCatalogElementFieldValue(value="333")]),
+        ],
+    )
 
 
 @pytest.mark.usefixtures("_successful_response")
@@ -75,8 +83,8 @@ def test_update_catalog_element_patch_correct_params(user, amocrm_client, patch,
                 "name": "PopugFields",
                 "custom_fields_values": [
                     {"field_id": 2235143, "values": [{"value": "not-hehe"}]},
-                    {"field_id": 2235147, "values": [{"value": 999.12}]},
-                    {"field_id": 2235151, "values": [{"value": 333}]},
+                    {"field_id": 2235147, "values": [{"value": "999.12"}]},
+                    {"field_id": 2235151, "values": [{"value": "333"}]},
                 ],
             },
         ],

--- a/src/amocrm/tests/tasks/tests_push_course.py
+++ b/src/amocrm/tests/tasks/tests_push_course.py
@@ -9,25 +9,27 @@ pytestmark = [
 
 @pytest.fixture
 def mock_course_creator(mocker):
-    mocker.patch("amocrm.services.course_creator.AmoCRMCourseCreator.__call__")
+    mocker.patch("amocrm.services.course_creator.AmoCRMCourseCreator.__call__", return_value=111)
     return mocker.patch("amocrm.services.course_creator.AmoCRMCourseCreator.__init__", return_value=None)
 
 
 @pytest.fixture
 def mock_course_updater(mocker):
-    mocker.patch("amocrm.services.course_updater.AmoCRMCourseUpdater.__call__")
+    mocker.patch("amocrm.services.course_updater.AmoCRMCourseUpdater.__call__", return_value=222)
     return mocker.patch("amocrm.services.course_updater.AmoCRMCourseUpdater.__init__", return_value=None)
 
 
 def test_call_course_creator_if_not_amocrm_course(course, mock_course_creator, mock_course_updater):
-    tasks.push_course(course_id=course.id)
+    got = tasks.push_course(course_id=course.id)
 
+    assert got == 111
     mock_course_creator.assert_called_once_with(course=course)
     mock_course_updater.assert_not_called()
 
 
 def test_call_course_updater_if_amocrm_course_exists(amocrm_course, mock_course_creator, mock_course_updater):
-    tasks.push_course(course_id=amocrm_course.course.id)
+    got = tasks.push_course(course_id=amocrm_course.course.id)
 
+    assert got == 222
     mock_course_updater.assert_called_once_with(amocrm_course=amocrm_course)
     mock_course_creator.assert_not_called()

--- a/src/amocrm/tests/tasks/tests_push_customer.py
+++ b/src/amocrm/tests/tasks/tests_push_customer.py
@@ -27,15 +27,18 @@ def test_call_creates_customer_if_not_amocrm_user(user, mock_create_customer, mo
 
 @pytest.mark.usefixtures("mock_create_customer")
 def test_creates_customer_if_not_amocrm_user(user):
-    tasks.push_customer(user_id=user.id)
+    got = tasks.push_customer(user_id=user.id)
 
     amocrm_user = AmoCRMUser.objects.get()
-    assert amocrm_user.amocrm_id == 4815
+    assert got == amocrm_user.amocrm_id == 4815
     assert amocrm_user.user == user
 
 
 def test_call_updates_customer_if_amocrm_user_exists(amocrm_user, mock_create_customer, mock_update_customer):
-    tasks.push_customer(user_id=amocrm_user.user.id)
+    amocrm_user.setattr_and_save("amocrm_id", 4815)
 
+    got = tasks.push_customer(user_id=amocrm_user.user.id)
+
+    assert got == amocrm_user.amocrm_id == 4815
     mock_update_customer.assert_called_once_with(amocrm_user=amocrm_user)
     mock_create_customer.assert_not_called()

--- a/src/amocrm/types.py
+++ b/src/amocrm/types.py
@@ -55,7 +55,7 @@ class AmoCRMCatalogElementFieldValue:
     value: str | int | Decimal
 
     def to_json(self) -> dict:
-        return asdict(self)
+        return {"value": str(self.value)}  # it stores as string in amocrm
 
     @classmethod
     def from_json(cls, data: dict) -> "AmoCRMCatalogElementFieldValue":


### PR DESCRIPTION
После пары тестовых запусков обнаружил ошибки в методах клиента:

1.  Исправил название поля с items на catalogs в get_catalogs
2.  Теперь все поля в create/update catalog element передаются как строки (так и надо, внутри AmoCRM они все лежат как строки)

Вдобавок еще сделал по https://github.com/tough-dev-school/education-backend/pull/1827#discussion_r1281727699 и https://github.com/tough-dev-school/education-backend/pull/1831#discussion_r1282623274 доработки