### PR TITLE
Push Courses, Group and Users

### DIFF
--- a/src/amocrm/tasks.py
+++ b/src/amocrm/tasks.py
@@ -79,3 +79,12 @@ def push_course(course_id: int) -> int:
         return AmoCRMCourseUpdater(amocrm_course=course.amocrm_course)()
     else:
         return AmoCRMCourseCreator(course=course)()
+
+
+@celery.task(
+    acks_late=True,
+)
+def push_all_courses() -> None:
+    courses = apps.get_model("products.Course").objects.all()
+    for course in courses:
+        push_course.delay(course_id=course.id)

--- a/src/amocrm/tasks.py
+++ b/src/amocrm/tasks.py
@@ -87,9 +87,7 @@ def push_course(course_id: int) -> int:
         return AmoCRMCourseCreator(course=course)()
 
 
-@celery.task(
-    acks_late=True,
-)
+@celery.task(acks_late=True)
 def push_all_courses() -> None:
     courses = apps.get_model("products.Course").objects.all()
     for course in courses:

--- a/src/amocrm/tests/tasks/tests_push_customer.py
+++ b/src/amocrm/tests/tasks/tests_push_customer.py
@@ -19,7 +19,7 @@ def mock_update_customer(mocker):
 
 
 def test_call_creates_customer_if_not_amocrm_user(user, mock_create_customer, mock_update_customer):
-    tasks.push_customer(user_id=user.id)
+    tasks._push_customer(user_id=user.id)
 
     mock_create_customer.assert_called_once_with(user=user)
     mock_update_customer.assert_not_called()
@@ -27,7 +27,7 @@ def test_call_creates_customer_if_not_amocrm_user(user, mock_create_customer, mo
 
 @pytest.mark.usefixtures("mock_create_customer")
 def test_creates_customer_if_not_amocrm_user(user):
-    got = tasks.push_customer(user_id=user.id)
+    got = tasks._push_customer(user_id=user.id)
 
     amocrm_user = AmoCRMUser.objects.get()
     assert got == amocrm_user.amocrm_id == 4815
@@ -37,7 +37,7 @@ def test_creates_customer_if_not_amocrm_user(user):
 def test_call_updates_customer_if_amocrm_user_exists(amocrm_user, mock_create_customer, mock_update_customer):
     amocrm_user.setattr_and_save("amocrm_id", 4815)
 
-    got = tasks.push_customer(user_id=amocrm_user.user.id)
+    got = tasks._push_customer(user_id=amocrm_user.user.id)
 
     assert got == amocrm_user.amocrm_id == 4815
     mock_update_customer.assert_called_once_with(amocrm_user=amocrm_user)

--- a/src/app/celery.py
+++ b/src/app/celery.py
@@ -30,13 +30,9 @@ celery.conf.update(
             "task": "chains.tasks.send_active_chains",
             "schedule": crontab(hour="*", minute="*/5"),
         },
-        "amocrm_push_all_courses": {
-            "task": "amocrm.tasks.push_all_courses",
+        "amocrm_push_all_products_and_product_groups": {
+            "task": "amocrm.tasks.push_all_products_and_product_groups",
             "schedule": crontab(minute="15", hour="*/2"),
-        },
-        "amocrm_push_all_product_groups": {
-            "task": "amocrm.tasks.push_product_groups",
-            "schedule": crontab(minute="5", hour="*/2"),
         },
     },
 )

--- a/src/app/celery.py
+++ b/src/app/celery.py
@@ -30,6 +30,14 @@ celery.conf.update(
             "task": "chains.tasks.send_active_chains",
             "schedule": crontab(hour="*", minute="*/5"),
         },
+        "amocrm_push_all_courses": {
+            "task": "amocrm.tasks.push_all_courses",
+            "schedule": crontab(minute="15", hour="*/2"),
+        },
+        "amocrm_push_all_product_groups": {
+            "task": "amocrm.tasks.push_product_groups",
+            "schedule": crontab(minute="5", hour="*/2"),
+        },
     },
 )
 

--- a/src/magnets/tests/tests_lead_magnet_creator.py
+++ b/src/magnets/tests/tests_lead_magnet_creator.py
@@ -57,7 +57,7 @@ def test_user_is_subscribed_with_tags(creator, mixer, rebuild_tags):
     user = mixer.blend(User, first_name="Фёдор", last_name="Шаляпин", email="support@m1crosoft.com")
     creator(name="r00t", email="support@m1crosoft.com")()
 
-    rebuild_tags.assert_called_once_with(user.id)
+    rebuild_tags.assert_called_once_with(student_id=user.id)
 
 
 def test_log_entry_is_created(creator, campaign):

--- a/src/magnets/tests/tests_lead_magnet_creator.py
+++ b/src/magnets/tests/tests_lead_magnet_creator.py
@@ -57,7 +57,7 @@ def test_user_is_subscribed_with_tags(creator, mixer, rebuild_tags):
     user = mixer.blend(User, first_name="Фёдор", last_name="Шаляпин", email="support@m1crosoft.com")
     creator(name="r00t", email="support@m1crosoft.com")()
 
-    rebuild_tags.assert_called_once_with(student_id=user.id)
+    rebuild_tags.assert_called_once_with(student_id=user.id, subscribe=True)
 
 
 def test_log_entry_is_created(creator, campaign):

--- a/src/orders/services/order_paid_setter.py
+++ b/src/orders/services/order_paid_setter.py
@@ -47,12 +47,16 @@ class OrderPaidSetter(BaseService):
         bank.successful_payment_callback()
 
     def update_user_tags(self) -> None:
-        if self.order.user.email and len(self.order.user.email):
+        can_be_subscribed = self.order.user.email and len(self.order.user.email)
+        if not can_be_subscribed and not amocrm_enabled():
+            rebuild_tags.delay(student_id=self.order.user.id, subscribe=False)
+
+        if can_be_subscribed:
             if amocrm_enabled():
                 tasks_chain = chain(
-                    rebuild_tags.si(student_id=self.order.user.id),
+                    rebuild_tags.si(student_id=self.order.user.id, subscribe=True),
                     push_customer.si(user_id=self.order.user.id).set(queue="amocrm"),
                 )
                 tasks_chain.delay()
             else:
-                rebuild_tags.delay(student_id=self.order.user.id)
+                rebuild_tags.delay(student_id=self.order.user.id, subscribe=True)

--- a/src/orders/tests/order_shipping/tests_order_set_paid.py
+++ b/src/orders/tests/order_shipping/tests_order_set_paid.py
@@ -13,6 +13,21 @@ def rebuild_tags(mocker):
     return mocker.patch("users.tasks.rebuild_tags.delay")
 
 
+@pytest.fixture
+def mock_update_user_chain(mocker):
+    return mocker.patch("orders.services.order_paid_setter.chain")
+
+
+@pytest.fixture
+def mock_rebuild_tags(mocker):
+    return mocker.patch("users.tasks.rebuild_tags.si")
+
+
+@pytest.fixture
+def mock_push_customer(mocker):
+    return mocker.patch("amocrm.tasks.push_customer.si")
+
+
 def test_works(order):
     assert order.paid is None
 
@@ -32,7 +47,18 @@ def test_ships(order, course, user, ship):
 def test_update_user_tags(order, rebuild_tags):
     order.set_paid()
 
-    rebuild_tags.assert_called_once_with(order.user.id)
+    rebuild_tags.assert_called_once_with(student_id=order.user.id)
+
+
+def test_call_update_user_celery_chain(order, mock_update_user_chain, mock_rebuild_tags, mock_push_customer, settings):
+    settings.AMOCRM_BASE_URL = "https://amo.amo.amo"
+
+    order.set_paid()
+
+    mock_update_user_chain.assert_called_once_with(
+        mock_rebuild_tags(student_id=order.user.id),
+        mock_push_customer(user_id=order.user.id).set(queue="amocrm"),
+    )
 
 
 def test_not_ships_if_order_is_already_paid(order, ship):

--- a/src/orders/tests/order_shipping/tests_order_set_paid.py
+++ b/src/orders/tests/order_shipping/tests_order_set_paid.py
@@ -47,7 +47,7 @@ def test_ships(order, course, user, ship):
 def test_update_user_tags(order, rebuild_tags):
     order.set_paid()
 
-    rebuild_tags.assert_called_once_with(student_id=order.user.id)
+    rebuild_tags.assert_called_once_with(student_id=order.user.id, subscribe=True)
 
 
 def test_call_update_user_celery_chain(order, mock_update_user_chain, mock_rebuild_tags, mock_push_customer, settings):

--- a/src/products/admin/course.py
+++ b/src/products/admin/course.py
@@ -1,5 +1,9 @@
+from typing import Any
+
+from django.http import HttpRequest
 from django.utils.translation import gettext as _
 
+from amocrm import tasks
 from app.admin import admin
 from app.admin import ModelAdmin
 from mailing.admin.email_configuration import EmailConfigurationAdmin
@@ -87,3 +91,9 @@ class CourseAdmin(ModelAdmin):
     @admin.display(boolean=True)
     def has_cover(self, course: Course) -> bool:
         return bool(course.cover)
+
+    def save_model(self, request: HttpRequest, obj: Course, form: Any, change: Any) -> None:
+        super().save_model(request, obj, form, change)
+
+        if tasks.amocrm_enabled():
+            tasks.push_course.delay(course_id=obj.pk)

--- a/src/products/admin/group.py
+++ b/src/products/admin/group.py
@@ -1,3 +1,8 @@
+from typing import Any
+
+from django.http import HttpRequest
+
+from amocrm import tasks
 from app.admin import admin
 from app.admin import ModelAdmin
 from products.models import Group
@@ -7,3 +12,9 @@ from products.models import Group
 class GroupAdmin(ModelAdmin):
     list_display = ["id", "name", "slug"]
     list_editable = ["name", "slug"]
+
+    def save_model(self, request: HttpRequest, obj: Group, form: Any, change: Any) -> None:
+        super().save_model(request, obj, form, change)
+
+        if tasks.amocrm_enabled():
+            tasks.push_product_groups.delay()

--- a/src/products/tests/course_api/tests_purchasing_course.py
+++ b/src/products/tests/course_api/tests_purchasing_course.py
@@ -57,7 +57,7 @@ def test_subscription_tags(call_purchase, rebuild_tags):
 
     placed = get_order()
 
-    rebuild_tags.assert_called_once_with(placed.user.id)
+    rebuild_tags.assert_called_once_with(student_id=placed.user.id)
 
 
 def test_by_default_user_is_not_subscribed(call_purchase):

--- a/src/products/tests/course_api/tests_purchasing_course.py
+++ b/src/products/tests/course_api/tests_purchasing_course.py
@@ -49,7 +49,7 @@ def test_user_auto_subscription(call_purchase, wants_to_subscribe, should_be_sub
     placed = get_order()
     placed.user.refresh_from_db()
 
-    assert rebuild_tags.called is should_be_subscribed
+    rebuild_tags.assert_called_once_with(student_id=placed.user.id, subscribe=should_be_subscribed)
 
 
 def test_subscription_tags(call_purchase, rebuild_tags):
@@ -57,7 +57,7 @@ def test_subscription_tags(call_purchase, rebuild_tags):
 
     placed = get_order()
 
-    rebuild_tags.assert_called_once_with(student_id=placed.user.id)
+    rebuild_tags.assert_called_once_with(student_id=placed.user.id, subscribe=True)
 
 
 def test_by_default_user_is_not_subscribed(call_purchase):

--- a/src/users/services/user_updater.py
+++ b/src/users/services/user_updater.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 
 from rest_framework import serializers
 
+from amocrm.tasks import amocrm_enabled
+from amocrm.tasks import push_customer
 from app.services import BaseService
 from diplomas.tasks import regenerate_diplomas
 from users.models import User
@@ -51,5 +53,11 @@ class UserUpdater(BaseService):
         if fields_used_in_diplomas.intersection(updated_fields):
             self.regenerate_diplomas()
 
+        if amocrm_enabled():
+            self.update_in_amocrm()
+
     def regenerate_diplomas(self) -> None:
         regenerate_diplomas.delay(student_id=self.user.id)
+
+    def update_in_amocrm(self) -> None:
+        push_customer.delay(user_id=self.user.id).set(queue="amocrm")

--- a/src/users/services/user_updater.py
+++ b/src/users/services/user_updater.py
@@ -60,4 +60,4 @@ class UserUpdater(BaseService):
         regenerate_diplomas.delay(student_id=self.user.id)
 
     def update_in_amocrm(self) -> None:
-        push_customer.delay(user_id=self.user.id).set(queue="amocrm")
+        push_customer.delay(user_id=self.user.id)

--- a/src/users/tasks.py
+++ b/src/users/tasks.py
@@ -8,9 +8,10 @@ from users.tags.pipeline import generate_tags
 
 
 @celery.task(name="users.rebuild_tags")
-def rebuild_tags(student_id: str | int) -> None:
+def rebuild_tags(student_id: str | int, subscribe: bool = True) -> None:
     time.sleep(1)  # preventing race condition when task looks for user which isn't saved into db yet
     student = apps.get_model("users.Student").objects.get(pk=student_id)
 
     generate_tags(student)
-    update_dashamail_subscription.delay(user_id=student.pk)
+    if subscribe:
+        update_dashamail_subscription.delay(user_id=student.pk)

--- a/src/users/tests/user_creator/tests_user_creator_subscription.py
+++ b/src/users/tests/user_creator/tests_user_creator_subscription.py
@@ -19,7 +19,7 @@ def test_user_is_not_subscribed_to_dashamail_by_default(rebuild_tags):
 def test_tags_are_passed(rebuild_tags):
     created = UserCreator(name="Рулон Обоев", email="rulon.oboev@gmail.com", subscribe=True)()
 
-    rebuild_tags.assert_called_once_with(created.id)
+    rebuild_tags.assert_called_once_with(student_id=created.id)
 
 
 def test_not_subscribed(rebuild_tags):

--- a/src/users/tests/user_creator/tests_user_creator_subscription.py
+++ b/src/users/tests/user_creator/tests_user_creator_subscription.py
@@ -11,21 +11,21 @@ def rebuild_tags(mocker):
 
 
 def test_user_is_not_subscribed_to_dashamail_by_default(rebuild_tags):
-    UserCreator(name="Рулон Обоев", email="rulon.oboev@gmail.com")()
+    created = UserCreator(name="Рулон Обоев", email="rulon.oboev@gmail.com")()
 
-    rebuild_tags.assert_not_called()
+    rebuild_tags.assert_called_once_with(student_id=created.id, subscribe=False)
 
 
 def test_tags_are_passed(rebuild_tags):
     created = UserCreator(name="Рулон Обоев", email="rulon.oboev@gmail.com", subscribe=True)()
 
-    rebuild_tags.assert_called_once_with(student_id=created.id)
+    rebuild_tags.assert_called_once_with(student_id=created.id, subscribe=True)
 
 
 def test_not_subscribed(rebuild_tags):
-    UserCreator(name="Рулон Обоев", email="rulon.oboev@gmail.com", subscribe=False)()
+    created = UserCreator(name="Рулон Обоев", email="rulon.oboev@gmail.com", subscribe=False)()
 
-    rebuild_tags.assert_not_called()
+    rebuild_tags.assert_called_once_with(student_id=created.id, subscribe=False)
 
 
 @pytest.mark.parametrize("wants_to_subscribe", [True, False])

--- a/src/users/tests/user_creator/tests_user_creator_update_chain.py
+++ b/src/users/tests/user_creator/tests_user_creator_update_chain.py
@@ -1,0 +1,50 @@
+import pytest
+
+from users.services import UserCreator
+
+pytestmark = [pytest.mark.django_db]
+
+
+@pytest.fixture
+def mock_update_user_chain(mocker):
+    return mocker.patch("users.services.user_creator.chain")
+
+
+@pytest.fixture
+def mock_rebuild_tags(mocker):
+    return mocker.patch("users.tasks.rebuild_tags.si")
+
+
+@pytest.fixture
+def mock_push_customer(mocker):
+    return mocker.patch("amocrm.tasks.push_customer.si")
+
+
+@pytest.fixture
+def push_customer(mocker):
+    return mocker.patch("amocrm.tasks.push_customer.delay")
+
+
+def test_call_create_user_celery_chain_if_subscribe_and_amocrm_enabled(mock_update_user_chain, mock_rebuild_tags, mock_push_customer, settings):
+    settings.AMOCRM_BASE_URL = "https://amo.amo.amo"
+
+    user = UserCreator(name="Рулон Обоев", email="rulon.oboev@gmail.com", subscribe=True)()
+
+    mock_update_user_chain.assert_called_once_with(
+        mock_rebuild_tags(student_id=user.id),
+        mock_push_customer(user_id=user.id).set(queue="amocrm"),
+    )
+
+
+def test_call_push_customer_if_not_subscribe_and_amocrm_enabled(push_customer, settings):
+    settings.AMOCRM_BASE_URL = "https://amo.amo.amo"
+
+    user = UserCreator(name="Рулон Обоев", email="rulon.oboev@gmail.com")()
+
+    push_customer.assert_called_once_with(user_id=user.id)
+
+
+def test_not_call_push_customer_if_not_subscribe_and_amocrm_disabled(push_customer):
+    UserCreator(name="Рулон Обоев", email="rulon.oboev@gmail.com")()
+
+    push_customer.assert_not_called()


### PR DESCRIPTION
Добавил в админку для Курса и Группы вызовы соотвествующих тасок для загрузки в амо

И добавил в UserCreator, UserUpdater, OrderPaidSetter таску push_customer
Уже здесь хочу использовать chain, чтобы покупатель загружался с соотвествующими тегами.

Есть баг с цепочками из-за которого настройки таски затираются на дефолтные в цепочке, поэтому завернул push_customer в родительскую таску, чтобы уже изнутри цепочки корректно запускалась таска.
https://github.com/celery/celery/issues/5219