### PR TITLE
refactor push_customer to push_user_to_amocrm with contact and link

### DIFF
--- a/src/orders/services/order_paid_setter.py
+++ b/src/orders/services/order_paid_setter.py
@@ -5,7 +5,7 @@ from celery import chain
 from django.utils import timezone
 
 from amocrm.tasks import amocrm_enabled
-from amocrm.tasks import push_customer
+from amocrm.tasks import push_user_to_amocrm
 from app.services import BaseService
 from banking.selector import get_bank
 from orders.models import Order
@@ -55,7 +55,7 @@ class OrderPaidSetter(BaseService):
             if amocrm_enabled():
                 tasks_chain = chain(
                     rebuild_tags.si(student_id=self.order.user.id, subscribe=True),
-                    push_customer.si(user_id=self.order.user.id).set(queue="amocrm"),
+                    push_user_to_amocrm.si(user_id=self.order.user.id).set(queue="amocrm"),
                 )
                 tasks_chain.delay()
             else:

--- a/src/orders/tests/order_shipping/tests_order_set_paid.py
+++ b/src/orders/tests/order_shipping/tests_order_set_paid.py
@@ -25,7 +25,7 @@ def mock_rebuild_tags(mocker):
 
 @pytest.fixture
 def mock_push_customer(mocker):
-    return mocker.patch("amocrm.tasks.push_customer.si")
+    return mocker.patch("amocrm.tasks.push_user_to_amocrm.si")
 
 
 def test_works(order):

--- a/src/users/services/user_creator.py
+++ b/src/users/services/user_creator.py
@@ -7,7 +7,7 @@ from rest_framework import serializers
 from django.utils.functional import cached_property
 
 from amocrm.tasks import amocrm_enabled
-from amocrm.tasks import push_customer
+from amocrm.tasks import push_user_to_amocrm
 from app.services import BaseService
 from users.models import User
 from users.tasks import rebuild_tags
@@ -70,7 +70,7 @@ class UserCreator(BaseService):
             if amocrm_enabled():
                 tasks_chain = chain(
                     rebuild_tags.si(student_id=created_user.id, subscribe=True),
-                    push_customer.si(user_id=created_user.id).set(queue="amocrm"),
+                    push_user_to_amocrm.si(user_id=created_user.id).set(queue="amocrm"),
                 )
                 tasks_chain.delay()
                 return None
@@ -78,4 +78,4 @@ class UserCreator(BaseService):
             rebuild_tags.delay(student_id=created_user.id, subscribe=True)
 
         else:
-            push_customer.delay(user_id=created_user.id)
+            push_user_to_amocrm.delay(user_id=created_user.id)

--- a/src/users/services/user_updater.py
+++ b/src/users/services/user_updater.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from rest_framework import serializers
 
 from amocrm.tasks import amocrm_enabled
-from amocrm.tasks import push_customer
+from amocrm.tasks import push_user_to_amocrm
 from app.services import BaseService
 from diplomas.tasks import regenerate_diplomas
 from users.models import User
@@ -60,4 +60,4 @@ class UserUpdater(BaseService):
         regenerate_diplomas.delay(student_id=self.user.id)
 
     def update_in_amocrm(self) -> None:
-        push_customer.delay(user_id=self.user.id)
+        push_user_to_amocrm.delay(user_id=self.user.id)

--- a/src/users/tests/user_creator/tests_user_creator_update_chain.py
+++ b/src/users/tests/user_creator/tests_user_creator_update_chain.py
@@ -17,12 +17,12 @@ def mock_rebuild_tags(mocker):
 
 @pytest.fixture
 def mock_push_customer(mocker):
-    return mocker.patch("amocrm.tasks.push_customer.si")
+    return mocker.patch("amocrm.tasks.push_user_to_amocrm.si")
 
 
 @pytest.fixture
 def push_customer(mocker):
-    return mocker.patch("amocrm.tasks.push_customer.delay")
+    return mocker.patch("amocrm.tasks.push_user_to_amocrm.delay")
 
 
 def test_call_create_user_celery_chain_if_subscribe_and_amocrm_enabled(mock_update_user_chain, mock_rebuild_tags, mock_push_customer, settings):


### PR DESCRIPTION
К [задаче](https://3.basecamp.com/5104612/buckets/29069198/todos/6388244363#__recording_6417626951)

Немного отрефакторил таску, теперь она комплексно передаёт пользователя в амосрм -> создаёт Контакт и Покупателя, а после - создаёт связь между ними.
В дальнейшем AmoCRMContactToCustomerLinker можно будет расширить с использованием контактов HR для контактов