### PR TITLE
refactor push_user_to_amocrm on chain instead of chord

### DIFF
--- a/src/amocrm/tasks.py
+++ b/src/amocrm/tasks.py
@@ -36,7 +36,7 @@ def push_user_to_amocrm(user_id: int) -> None:
         _push_contact.si(user_id=user_id),
         _link_contact_to_user.si(user_id=user_id),
     )
-    return tasks_chain.get()
+    return tasks_chain.delay()
 
 
 @celery.task(

--- a/src/amocrm/tasks.py
+++ b/src/amocrm/tasks.py
@@ -1,4 +1,4 @@
-from celery import chord
+from celery import chain
 from httpx import TransportError
 
 from django.apps import apps
@@ -31,15 +31,12 @@ def amocrm_enabled() -> bool:
     acks_late=True,
 )
 def push_user_to_amocrm(user_id: int) -> None:
-    tasks_chord = chord(
-        [
-            _push_customer.si(user_id=user_id),
-            _push_contact.si(user_id=user_id),
-        ]
-    )(
+    tasks_chain = chain(
+        _push_customer.si(user_id=user_id),
+        _push_contact.si(user_id=user_id),
         _link_contact_to_user.si(user_id=user_id),
     )
-    return tasks_chord.get()
+    return tasks_chain.get()
 
 
 @celery.task(


### PR DESCRIPTION
Chord не работает без ResultBackend. Чтобы не менять конфиг, переделал на chain
`NotImplementedError('Starting chords requires a result backend to be configured.\n\nNote that a group chained with a task is also upgraded to be a chord,\nas this pattern requires synchronization.\n\nResult backends that supports chords: Redis, Database, Memcached, and more.')`