### PR TITLE
Insert push order task

### DIFF
--- a/src/amocrm/management/commands/export_amocrm_users.py
+++ b/src/amocrm/management/commands/export_amocrm_users.py
@@ -1,5 +1,6 @@
 from django.apps import apps
 from django.core.management.base import BaseCommand
+from django.db.models import Q
 
 from amocrm.tasks import push_user_to_amocrm
 
@@ -10,8 +11,12 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         Order = apps.get_model("orders.Order")
 
-        users_ids_with_orders = Order.objects.all().values_list("user_id", flat=True)
-        for user_id in set(users_ids_with_orders):
+        users_ids = (
+            Order.objects.filter(~Q(user__email=""), unpaid__isnull=True, user__is_active=True, user__is_staff=False, user__email__isnull=False)
+            .select_related("user")
+            .values_list("user_id", flat=True)
+        )
+        for user_id in set(users_ids):
             push_user_to_amocrm.delay(user_id=user_id)
 
         self.stdout.write(self.style.SUCCESS("Tasks for exporting users has been successfully created."))

--- a/src/amocrm/tests/services/order/conftest.py
+++ b/src/amocrm/tests/services/order/conftest.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _mock_tasks_with_paid_setter(mocker):
-    mocker.patch("orders.services.order_paid_setter.OrderPaidSetter.update_user_tags", return_value=None)
+    mocker.patch("orders.services.order_paid_setter.OrderPaidSetter.after_shipment", return_value=None)
 
 
 @pytest.fixture

--- a/src/orders/services/order_paid_setter.py
+++ b/src/orders/services/order_paid_setter.py
@@ -5,6 +5,7 @@ from celery import chain
 from django.utils import timezone
 
 from amocrm.tasks import amocrm_enabled
+from amocrm.tasks import push_order_to_amocrm
 from amocrm.tasks import push_user_to_amocrm
 from app.services import BaseService
 from banking.selector import get_bank
@@ -28,7 +29,7 @@ class OrderPaidSetter(BaseService):
         self.mark_order_as_paid()
         self.call_bank_successfull_callback()
         self.ship()
-        self.update_user_tags()
+        self.after_shipment()
 
     def mark_order_as_paid(self) -> None:
         self.order.paid = timezone.now()
@@ -46,17 +47,23 @@ class OrderPaidSetter(BaseService):
         bank = Bank(order=self.order)
         bank.successful_payment_callback()
 
-    def update_user_tags(self) -> None:
+    def after_shipment(self) -> None:
         can_be_subscribed = self.order.user.email and len(self.order.user.email)
         if not can_be_subscribed and not amocrm_enabled():
             rebuild_tags.delay(student_id=self.order.user.id, subscribe=False)
 
-        if can_be_subscribed:
-            if amocrm_enabled():
-                tasks_chain = chain(
-                    rebuild_tags.si(student_id=self.order.user.id, subscribe=True),
-                    push_user_to_amocrm.si(user_id=self.order.user.id).set(queue="amocrm"),
-                )
-                tasks_chain.delay()
-            else:
-                rebuild_tags.delay(student_id=self.order.user.id, subscribe=True)
+        if can_be_subscribed and amocrm_enabled():
+            chain(
+                rebuild_tags.si(student_id=self.order.user.id, subscribe=True),
+                push_user_to_amocrm.si(user_id=self.order.user.id),
+                push_order_to_amocrm.si(order_id=self.order.id),
+            ).delay()
+            return None
+
+        if not can_be_subscribed and amocrm_enabled():
+            chain(
+                rebuild_tags.si(student_id=self.order.user.id, subscribe=False),
+                push_user_to_amocrm.si(user_id=self.order.user.id),
+                push_order_to_amocrm.si(order_id=self.order.id),
+            ).delay()
+            return None

--- a/src/orders/tests/order_creator/tests_order_creator_update_chain.py
+++ b/src/orders/tests/order_creator/tests_order_creator_update_chain.py
@@ -1,0 +1,85 @@
+import pytest
+
+pytestmark = [pytest.mark.django_db]
+
+
+@pytest.fixture
+def mock_update_user_chain(mocker):
+    return mocker.patch("orders.services.order_creator.chain")
+
+
+@pytest.fixture
+def mock_rebuild_tags(mocker):
+    return mocker.patch("users.tasks.rebuild_tags.si")
+
+
+@pytest.fixture
+def rebuild_tags(mocker):
+    return mocker.patch("users.tasks.rebuild_tags.delay")
+
+
+@pytest.fixture
+def mock_push_customer(mocker):
+    return mocker.patch("amocrm.tasks.push_user_to_amocrm.si")
+
+
+@pytest.fixture
+def mock_push_order(mocker):
+    return mocker.patch("amocrm.tasks.push_order_to_amocrm.si")
+
+
+def test_if_subscribe_and_amocrm_enabled(create, user, course, mock_update_user_chain, mock_rebuild_tags, mock_push_customer, settings, mock_push_order):
+    settings.AMOCRM_BASE_URL = "https://amo.amo.amo"
+
+    order = create(user=user, item=course)
+
+    mock_update_user_chain.assert_called_once_with(
+        mock_rebuild_tags(student_id=user.id, subscribe=True),
+        mock_push_customer(user_id=user.id),
+        mock_push_order(order_id=order.id),
+    )
+
+
+def test_if_not_subscribe_and_amocrm_enabled(create, user, course, mock_update_user_chain, mock_rebuild_tags, mock_push_customer, settings, mock_push_order):
+    settings.AMOCRM_BASE_URL = "https://amo.amo.amo"
+    user.email = ""
+    user.save()
+
+    order = create(user=user, item=course)
+
+    mock_update_user_chain.assert_called_once_with(
+        mock_rebuild_tags(student_id=user.id, subscribe=False),
+        mock_push_customer(user_id=user.id),
+        mock_push_order(order_id=order.id),
+    )
+
+
+def test_if_not_subscribe_and_amocrm_disabled(
+    create, user, course, rebuild_tags, mock_update_user_chain, mock_rebuild_tags, mock_push_customer, settings, mock_push_order
+):
+    user.email = ""
+    user.save()
+
+    create(user=user, item=course)
+
+    rebuild_tags.assert_called_once_with(student_id=user.id, subscribe=False)
+    mock_update_user_chain.assert_not_called()
+    mock_rebuild_tags.assert_not_called()
+    mock_push_customer.assert_not_called()
+    mock_push_order.assert_not_called()
+
+
+def test_if_not_subscribe_and_not_push_to_amocrm(
+    create, user, course, rebuild_tags, mock_update_user_chain, mock_rebuild_tags, mock_push_customer, settings, mock_push_order
+):
+    settings.AMOCRM_BASE_URL = "https://amo.amo.amo"
+    user.email = ""
+    user.save()
+
+    create(user=user, item=course, push_to_amocrm=False)
+
+    rebuild_tags.assert_called_once_with(student_id=user.id, subscribe=False)
+    mock_update_user_chain.assert_not_called()
+    mock_rebuild_tags.assert_not_called()
+    mock_push_customer.assert_not_called()
+    mock_push_order.assert_not_called()

--- a/src/users/tests/user_creator/tests_user_creator_update_chain.py
+++ b/src/users/tests/user_creator/tests_user_creator_update_chain.py
@@ -20,31 +20,42 @@ def mock_push_customer(mocker):
     return mocker.patch("amocrm.tasks.push_user_to_amocrm.si")
 
 
-@pytest.fixture
-def push_customer(mocker):
-    return mocker.patch("amocrm.tasks.push_user_to_amocrm.delay")
-
-
 def test_call_create_user_celery_chain_if_subscribe_and_amocrm_enabled(mock_update_user_chain, mock_rebuild_tags, mock_push_customer, settings):
     settings.AMOCRM_BASE_URL = "https://amo.amo.amo"
 
     user = UserCreator(name="Рулон Обоев", email="rulon.oboev@gmail.com", subscribe=True)()
 
     mock_update_user_chain.assert_called_once_with(
-        mock_rebuild_tags(student_id=user.id),
-        mock_push_customer(user_id=user.id).set(queue="amocrm"),
+        mock_rebuild_tags(student_id=user.id, subscribe=True),
+        mock_push_customer(user_id=user.id),
     )
 
 
-def test_call_push_customer_if_not_subscribe_and_amocrm_enabled(push_customer, settings):
+def test_call_push_customer_if_not_subscribe_and_amocrm_enabled(mock_push_customer, settings, mock_update_user_chain, mock_rebuild_tags):
     settings.AMOCRM_BASE_URL = "https://amo.amo.amo"
 
     user = UserCreator(name="Рулон Обоев", email="rulon.oboev@gmail.com")()
 
-    push_customer.assert_called_once_with(user_id=user.id)
+
+    mock_update_user_chain.assert_called_once_with(
+        mock_rebuild_tags(student_id=user.id, subscribe=False),
+        mock_push_customer(user_id=user.id),
+    )
 
 
-def test_not_call_push_customer_if_not_subscribe_and_amocrm_disabled(push_customer):
+def test_not_call_push_customer_if_not_subscribe_and_amocrm_disabled(mock_update_user_chain, mock_rebuild_tags, mock_push_customer):
     UserCreator(name="Рулон Обоев", email="rulon.oboev@gmail.com")()
 
-    push_customer.assert_not_called()
+    mock_update_user_chain.assert_not_called()
+    mock_rebuild_tags.assert_not_called()
+    mock_push_customer.assert_not_called()
+
+
+def test_not_call_push_customer_if_not_subscribe_and_not_push_to_amocrm(mock_update_user_chain, mock_rebuild_tags, mock_push_customer, settings):
+    settings.AMOCRM_BASE_URL = "https://amo.amo.amo"
+
+    UserCreator(name="Рулон Обоев", email="rulon.oboev@gmail.com", push_to_amocrm=False)()
+
+    mock_update_user_chain.assert_not_called()
+    mock_rebuild_tags.assert_not_called()
+    mock_push_customer.assert_not_called()

--- a/src/users/tests/user_creator/tests_user_creator_update_chain.py
+++ b/src/users/tests/user_creator/tests_user_creator_update_chain.py
@@ -36,7 +36,6 @@ def test_call_push_customer_if_not_subscribe_and_amocrm_enabled(mock_push_custom
 
     user = UserCreator(name="Рулон Обоев", email="rulon.oboev@gmail.com")()
 
-
     mock_update_user_chain.assert_called_once_with(
         mock_rebuild_tags(student_id=user.id, subscribe=False),
         mock_push_customer(user_id=user.id),


### PR DESCRIPTION
К [задаче](https://3.basecamp.com/5104612/buckets/29069198/todos/6388244363#__recording_6427965891) 

Обновил методы after_creation / after_shipment для UserCreator/OrderCreator/OrderPaidSetter/PurchaseCreator так, чтобы теперь в амо также отправялась инфа о заказе

Также немного пофиксил команды для экспорта в амо