### PR TITLE
Allow link lead if there is transaction

### DIFF
--- a/src/amocrm/services/orders/order_lead_to_course_linker.py
+++ b/src/amocrm/services/orders/order_lead_to_course_linker.py
@@ -53,13 +53,8 @@ class AmoCRMOrderLeadToCourseLinker(BaseService):
 
     def get_validators(self) -> list[Callable]:
         return [
-            self.validate_transaction_doesnt_exist,
             self.validate_amocrm_course_exist,
         ]
-
-    def validate_transaction_doesnt_exist(self) -> None:
-        if hasattr(self.order, "amocrm_transaction"):
-            raise AmoCRMOrderLeadToCourseLinkerException("Transaction for this lead already exists")
 
     def validate_amocrm_course_exist(self) -> None:
         if not hasattr(self.order.course, "amocrm_course"):

--- a/src/amocrm/tests/services/order/tests_lead_to_course_linker.py
+++ b/src/amocrm/tests/services/order/tests_lead_to_course_linker.py
@@ -48,11 +48,3 @@ def test_fails_if_no_course(lead_course_linker, amocrm_lead):
 
     with pytest.raises(AmoCRMOrderLeadToCourseLinkerException):
         lead_course_linker(amocrm_lead)
-
-
-@pytest.mark.usefixtures("amocrm_course")
-def test_fails_if_transaction_exist(lead_course_linker, amocrm_lead, factory):
-    factory.amocrm_order_transaction(order=amocrm_lead.order)
-
-    with pytest.raises(AmoCRMOrderLeadToCourseLinkerException):
-        lead_course_linker(amocrm_lead)


### PR DESCRIPTION
При тестировании понял, что должно быть допустимо обновлять связь, если уже есть покупка. Т.к. Заказ может быть возвращен, а Покупка в последствии удалена (т.е. и сделку и покупку можно изменять уже из оплаченного состояния)