### PR TITLE
check if there is no amocrm transaction already

### DIFF
--- a/src/amocrm/tasks.py
+++ b/src/amocrm/tasks.py
@@ -219,7 +219,7 @@ def _push_transaction(order_id: int) -> int | None:
     order = apps.get_model("orders.Order").objects.get(id=order_id)
     if order.unpaid is not None:
         return AmoCRMOrderTransactionDeleter(order=order)()
-    if order.paid is not None:
+    if order.paid is not None and not hasattr(order, "amocrm_transaction"):
         return AmoCRMOrderTransactionCreator(order=order)()
 
 


### PR DESCRIPTION
С бесплатными курсами почти в одно время срабатывает сразу два сервиса OrderCreator и OrderPaidSetter и оба инициируют таски на загрузку заказа в Амо. 
Была проблема в том, что уже первая таска отрабатывает так, что заказ оплачен и создает транзакцию, из-за этого вторая таска падала с ошибкой.
Добавил проверку, чтобы при подобном. сценарии система не пыталась создать Покупку снова (из-за этого была ошибка)