### PR TITLE
allow update lead for paid free orders

### DIFF
--- a/src/amocrm/services/orders/order_lead_updater.py
+++ b/src/amocrm/services/orders/order_lead_updater.py
@@ -66,14 +66,15 @@ class AmoCRMOrderLeadUpdater(BaseService):
 
     def get_validators(self) -> list[Callable]:
         return [
-            self.validate_transaction_doesnt_exist_if_paid,
+            self.validate_transaction_doesnt_exist_if_paid_and_not_free,
             self.validate_order_with_course,
             self.validate_amocrm_course_exist,
             self.validate_amocrm_contact_exist,
         ]
 
-    def validate_transaction_doesnt_exist_if_paid(self) -> None:
-        if hasattr(self.order, "amocrm_transaction") and self.is_paid:
+    def validate_transaction_doesnt_exist_if_paid_and_not_free(self) -> None:
+        """N.B. Free orders are paid almost as soon as they have been created"""
+        if hasattr(self.order, "amocrm_transaction") and self.is_paid and self.order.price > 0:
             raise AmoCRMOrderLeadUpdaterException("Transaction for this paid order already exists")
 
     def validate_order_with_course(self) -> None:

--- a/src/amocrm/tests/services/order/tests_order_lead_updater.py
+++ b/src/amocrm/tests/services/order/tests_order_lead_updater.py
@@ -102,10 +102,22 @@ def test_updates_correct_call_for_not_paid_or_unpaid(lead_updater, amocrm_lead, 
 
 
 def test_fails_if_paid_and_transaction_already_exist(lead_updater, amocrm_lead, factory):
+    amocrm_lead.order.price = 100500
+    amocrm_lead.order.save()
     factory.amocrm_order_transaction(order=amocrm_lead.order)
 
     with pytest.raises(AmoCRMOrderLeadUpdaterException, match="Transaction for this paid order already exists"):
         lead_updater(amocrm_lead)
+
+
+def test_doesnt_fail_if_paid_and_transaction_already_exist_but_free(lead_updater, amocrm_lead, factory, mock_update_lead):
+    amocrm_lead.order.price = 0
+    amocrm_lead.order.save()
+    factory.amocrm_order_transaction(order=amocrm_lead.order)
+
+    lead_updater(amocrm_lead)
+
+    mock_update_lead.assert_called_once()
 
 
 def test_fails_if_no_course(lead_updater, amocrm_lead):


### PR DESCRIPTION
Исправил [баг](https://f213.sentry.io/issues/4392076004/?alert_rule_id=896167&alert_timestamp=1691933430518&alert_type=email&environment=production&project=1807512&referrer=alert_email)

Была проблема с бесплатными курсами, тк изначально отправлялся набор тасок с уже оплаченным заказом из OrderCreator, из-за чего не мог корректно пройти апдейт. Добавил проверку на то, что заказ бесплатный