### PR TITLE
do not push free unshipped orders

### DIFF
--- a/src/orders/services/order_creator.py
+++ b/src/orders/services/order_creator.py
@@ -94,7 +94,7 @@ class OrderCreator(BaseService):
         push_to_amocrm = self.push_to_amocrm and amocrm_enabled()
 
         can_be_subscribed = bool(self.subscribe_user and order.user.email and len(order.user.email))
-        if push_to_amocrm:
+        if push_to_amocrm and order.price > 0:  # do not push free unshipped orders
             chain(
                 rebuild_tags.si(student_id=order.user.id, subscribe=can_be_subscribed),
                 push_user_to_amocrm.si(user_id=order.user.id),

--- a/src/orders/tests/order_creator/tests_order_creator_update_chain.py
+++ b/src/orders/tests/order_creator/tests_order_creator_update_chain.py
@@ -1,5 +1,7 @@
 import pytest
 
+from _decimal import Decimal
+
 pytestmark = [pytest.mark.django_db]
 
 
@@ -61,6 +63,20 @@ def test_if_not_subscribe_and_amocrm_disabled(
     user.save()
 
     create(user=user, item=course)
+
+    rebuild_tags.assert_called_once_with(student_id=user.id, subscribe=False)
+    mock_update_user_chain.assert_not_called()
+    mock_rebuild_tags.assert_not_called()
+    mock_push_customer.assert_not_called()
+    mock_push_order.assert_not_called()
+
+
+def test_dont_call_if_free_order(create, user, course, mock_update_user_chain, mock_rebuild_tags, mock_push_customer, settings, mock_push_order, rebuild_tags):
+    settings.AMOCRM_BASE_URL = "https://amo.amo.amo"
+    user.email = ""
+    user.save()
+
+    create(user=user, item=course, price=Decimal(0))
 
     rebuild_tags.assert_called_once_with(student_id=user.id, subscribe=False)
     mock_update_user_chain.assert_not_called()


### PR DESCRIPTION
Только созданные "бесплатные" заказы больше не пушатся в амо. Т.к. при оформлении беслпатного курса сразу происходит и создание и "оплата" курса, это сократит количество вызовов тасок для стриминга в амо