### PR TITLE
Push one order for user per course

### DIFF
--- a/src/amocrm/services/orders/order_duplicate_checker.py
+++ b/src/amocrm/services/orders/order_duplicate_checker.py
@@ -28,7 +28,7 @@ class AmoCRMOrderDuplicateChecker(BaseService):
         user = self.order.user
 
         paid_order = Order.objects.filter(user=user, course=course, paid__isnull=False, unpaid__isnull=True).last()
-        if paid_order is not None:
+        if paid_order is not None and paid_order != self.order:
             return None
 
         orders_with_same_user_and_course = Order.objects.filter(user=user, course=course, paid__isnull=True, unpaid__isnull=True).exclude(pk=self.order.pk)

--- a/src/amocrm/services/orders/order_duplicate_checker.py
+++ b/src/amocrm/services/orders/order_duplicate_checker.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass
+from typing import Callable
+
+from django.db.models import QuerySet
+
+from amocrm.exceptions import AmoCRMServiceException
+from app.services import BaseService
+from orders.models import Order
+
+
+class AmoCRMOrderDuplicateCheckerException(AmoCRMServiceException):
+    """Raises when it's impossible to check order duplicates in amocrm"""
+
+
+@dataclass
+class AmoCRMOrderDuplicateChecker(BaseService):
+    """
+    Check for order with same course and user in amocrm
+
+    - if there is a paid order with same course and user -> return None
+    - if there is a not paid order with lead in amocrm -> link its lead to the new order and return this order
+    """
+
+    order: Order
+
+    def act(self) -> Order | None:
+        course = self.order.course
+        user = self.order.user
+
+        paid_order = Order.objects.filter(user=user, course=course, paid__isnull=False, unpaid__isnull=True).last()
+        if paid_order is not None:
+            return None
+
+        orders_with_same_user_and_course = Order.objects.filter(user=user, course=course, paid__isnull=True, unpaid__isnull=True).exclude(pk=self.order.pk)
+        self.link_lead_to_new_order(orders=orders_with_same_user_and_course)
+
+        return self.order
+
+    def link_lead_to_new_order(self, orders: QuerySet[Order]) -> None:
+        orders_with_lead = [order for order in orders if hasattr(order, "amocrm_lead")]
+        if len(orders_with_lead) == 1:
+            amocrm_lead = orders_with_lead[0].amocrm_lead
+            amocrm_lead.order = self.order
+            amocrm_lead.save()
+        elif len(orders_with_lead) > 1:
+            raise AmoCRMOrderDuplicateCheckerException("There are duplicates for such order with same course and user")
+
+    def get_validators(self) -> list[Callable]:
+        return [
+            self.validate_order_with_course,
+        ]
+
+    def validate_order_with_course(self) -> None:
+        if self.order.course is None:
+            raise AmoCRMOrderDuplicateCheckerException("Order has no course")

--- a/src/amocrm/tasks.py
+++ b/src/amocrm/tasks.py
@@ -14,6 +14,7 @@ from amocrm.services.access_token_getter import AmoCRMTokenGetterException
 from amocrm.services.contacts.contact_creator import AmoCRMContactCreator
 from amocrm.services.contacts.contact_to_customer_linker import AmoCRMContactToCustomerLinker
 from amocrm.services.contacts.contact_updater import AmoCRMContactUpdater
+from amocrm.services.orders.order_duplicate_checker import AmoCRMOrderDuplicateChecker
 from amocrm.services.orders.order_lead_creator import AmoCRMOrderLeadCreator
 from amocrm.services.orders.order_lead_creator import AmoCRMOrderLeadCreatorException
 from amocrm.services.orders.order_lead_deleter import AmoCRMOrderLeadDeleter
@@ -47,6 +48,8 @@ def order_must_be_pushed(order: "Order") -> bool:
     if order.author_id != order.user_id:
         return False
     if order.price == 0:
+        return False
+    if AmoCRMOrderDuplicateChecker(order=order)() is None:
         return False
     return True
 

--- a/src/amocrm/tests/conftest.py
+++ b/src/amocrm/tests/conftest.py
@@ -18,3 +18,9 @@ def amocrm_user(factory, user):
 @pytest.fixture
 def amocrm_course(factory, course):
     return factory.amocrm_course(course=course)
+
+
+@pytest.fixture(autouse=True)
+def _mock_tasks_with_paid_setter(mocker):
+    mocker.patch("orders.services.order_paid_setter.OrderPaidSetter.after_shipment", return_value=None)
+    mocker.patch("orders.services.order_unpaid_setter.OrderUnpaidSetter.after_unshipment", return_value=None)

--- a/src/amocrm/tests/services/order/conftest.py
+++ b/src/amocrm/tests/services/order/conftest.py
@@ -1,12 +1,6 @@
 import pytest
 
 
-@pytest.fixture(autouse=True)
-def _mock_tasks_with_paid_setter(mocker):
-    mocker.patch("orders.services.order_paid_setter.OrderPaidSetter.after_shipment", return_value=None)
-    mocker.patch("orders.services.order_unpaid_setter.OrderUnpaidSetter.after_unshipment", return_value=None)
-
-
 @pytest.fixture
 def order(factory, amocrm_course, amocrm_user):
     factory.amocrm_user_contact(user=amocrm_user.user)

--- a/src/amocrm/tests/services/order/tests_order_duplicate_checker.py
+++ b/src/amocrm/tests/services/order/tests_order_duplicate_checker.py
@@ -51,6 +51,13 @@ def test_new_order_if_no_same_orders(duplicate_checker, not_paid_order):
     assert not hasattr(got, "amocrm_lead")
 
 
+def test_new_paid_order_if_no_same_orders(duplicate_checker, paid_order):
+    got = duplicate_checker(order=paid_order)
+
+    assert got == paid_order
+    assert not hasattr(got, "amocrm_lead")
+
+
 def test_new_order_linked_to_old_unfinished_lead(duplicate_checker, not_paid_order, unfinished_lead):
     got = duplicate_checker(order=not_paid_order)
 

--- a/src/amocrm/tests/services/order/tests_order_duplicate_checker.py
+++ b/src/amocrm/tests/services/order/tests_order_duplicate_checker.py
@@ -1,0 +1,75 @@
+import pytest
+
+from amocrm.services.orders.order_duplicate_checker import AmoCRMOrderDuplicateChecker
+from amocrm.services.orders.order_duplicate_checker import AmoCRMOrderDuplicateCheckerException
+
+pytestmark = [
+    pytest.mark.django_db,
+]
+
+
+@pytest.fixture
+def paid_order(user, course, factory):
+    return factory.order(user=user, course=course, is_paid=True)
+
+
+@pytest.fixture
+def not_paid_order(factory, user, course):
+    return factory.order(user=user, course=course, is_paid=False)
+
+
+@pytest.fixture
+def unfinished_lead(factory, user, course):
+    order = factory.order(user=user, course=course, is_paid=False)
+    return factory.amocrm_order_lead(order=order)
+
+
+@pytest.fixture
+def duplicate_checker():
+    return lambda order: AmoCRMOrderDuplicateChecker(order=order)()
+
+
+def test_none_if_there_is_paid_order(duplicate_checker, not_paid_order, paid_order):
+    got = duplicate_checker(order=not_paid_order)
+
+    assert got is None
+
+
+def test_new_order_if_has_returned_order(duplicate_checker, not_paid_order, paid_order):
+    paid_order.set_not_paid()
+
+    got = duplicate_checker(order=not_paid_order)
+
+    assert got == not_paid_order
+    assert not hasattr(got, "amocrm_lead")
+
+
+def test_new_order_if_no_same_orders(duplicate_checker, not_paid_order):
+    got = duplicate_checker(order=not_paid_order)
+
+    assert got == not_paid_order
+    assert not hasattr(got, "amocrm_lead")
+
+
+def test_new_order_linked_to_old_unfinished_lead(duplicate_checker, not_paid_order, unfinished_lead):
+    got = duplicate_checker(order=not_paid_order)
+
+    assert got == not_paid_order
+    assert got.amocrm_lead == unfinished_lead
+
+
+def test_fails_if_many_lead_for_same_course_and_user(duplicate_checker, factory, not_paid_order):
+    orders = factory.cycle(2).order(user=not_paid_order.user, course=not_paid_order.course, is_paid=False)
+    for order in orders:
+        factory.amocrm_order_lead(order=order)
+
+    with pytest.raises(AmoCRMOrderDuplicateCheckerException, match="There are duplicates for such order with same course and user"):
+        duplicate_checker(not_paid_order)
+
+
+def test_fails_if_order_without_course(duplicate_checker, not_paid_order):
+    not_paid_order.course = None
+    not_paid_order.save()
+
+    with pytest.raises(AmoCRMOrderDuplicateCheckerException, match="Order has no course"):
+        duplicate_checker(not_paid_order)

--- a/src/amocrm/tests/tasks/tests_push_order_to_amocrm.py
+++ b/src/amocrm/tests/tasks/tests_push_order_to_amocrm.py
@@ -30,15 +30,20 @@ def mock_chain(mocker):
 
 
 @pytest.fixture
-def order_with_lead(factory, user):
-    order = factory.order(id=99, price=100, user=user, author=user)
+def order_with_lead(factory, user, course):
+    order = factory.order(id=99, price=100, user=user, course=course, author=user)
     factory.amocrm_order_lead(order=order)
     return order
 
 
 @pytest.fixture
-def order_without_lead(factory, user):
-    return factory.order(id=99, price=100, user=user, author=user)
+def order_without_lead(factory, user, course):
+    return factory.order(id=99, price=100, user=user, course=course, author=user)
+
+
+@pytest.fixture
+def paid_order(factory, user, course):
+    return factory.order(id=199, price=100, user=user, course=course, author=user, is_paid=True)
 
 
 def test_call_with_lead(order_with_lead, mock_push_lead, mock_push_transaction, mock_link_course_to_lead, mock_chain):
@@ -64,6 +69,18 @@ def test_call_without_lead(order_without_lead, mock_push_lead, mock_push_transac
     )
 
 
+def test_call_paid(paid_order, mock_push_lead, mock_push_transaction, mock_link_course_to_lead, mock_chain):
+    got = tasks.push_order_to_amocrm(order_id=paid_order.id)
+
+    assert got is None
+    mock_chain.assert_called_once_with(
+        mock_push_lead(order_id=199),
+        mock_link_course_to_lead(order_id=199),
+        mock_push_lead(order_id=199),
+        mock_push_transaction(order_id=199),
+    )
+
+
 def test_not_push_if_author_not_equal_to_user(order_without_lead, mock_chain, another_user):
     order_without_lead.author = another_user
     order_without_lead.save()
@@ -78,6 +95,13 @@ def test_not_push_if_free_order(order_without_lead, mock_chain):
     order_without_lead.price = Decimal(0)
     order_without_lead.save()
 
+    got = tasks.push_order_to_amocrm(order_id=order_without_lead.id)
+
+    assert got == "not for amocrm"
+    mock_chain.assert_not_called()
+
+
+def test_not_push_if_there_is_already_paid_order(order_without_lead, paid_order, mock_chain):
     got = tasks.push_order_to_amocrm(order_id=order_without_lead.id)
 
     assert got == "not for amocrm"


### PR DESCRIPTION
К [задаче](https://3.basecamp.com/5104612/buckets/29069198/todos/6456122047) 

Добавил сервис AmoCRMOrderDuplicateChecker, который отвечает за проверку на наличие идентичных заказов в амо (проверяет курс + юзер).
Если есть уже оплаченный заказ - возвращает None
Если есть уже открытая сделка по аналогичному заказу - привязывает эту сделку к текущему заказу и вызывает последующие таски
Если нет аналогичных заказов - вызывает последующие таски