### PR TITLE
refactor push_order_to_amocrm and AmoCRMOrderDuplicateChecker

### DIFF
--- a/src/amocrm/tests/services/order/tests_order_duplicate_checker.py
+++ b/src/amocrm/tests/services/order/tests_order_duplicate_checker.py
@@ -35,34 +35,30 @@ def test_none_if_there_is_paid_order(duplicate_checker, not_paid_order, paid_ord
     assert got is None
 
 
-def test_new_order_if_has_returned_order(duplicate_checker, not_paid_order, paid_order):
+def test_none_if_has_returned_order(duplicate_checker, not_paid_order, paid_order):
     paid_order.set_not_paid()
 
     got = duplicate_checker(order=not_paid_order)
 
-    assert got == not_paid_order
-    assert not hasattr(got, "amocrm_lead")
+    assert got is None
 
 
-def test_new_order_if_no_same_orders(duplicate_checker, not_paid_order):
+def test_none_if_no_same_orders(duplicate_checker, not_paid_order):
     got = duplicate_checker(order=not_paid_order)
 
-    assert got == not_paid_order
-    assert not hasattr(got, "amocrm_lead")
+    assert got is None
 
 
-def test_new_paid_order_if_no_same_orders(duplicate_checker, paid_order):
+def test_none_for_new_paid_order_if_no_same_orders(duplicate_checker, paid_order):
     got = duplicate_checker(order=paid_order)
 
-    assert got == paid_order
-    assert not hasattr(got, "amocrm_lead")
+    assert got is None
 
 
-def test_new_order_linked_to_old_unfinished_lead(duplicate_checker, not_paid_order, unfinished_lead):
+def test_old_order_linked_to_unfinished_lead(duplicate_checker, not_paid_order, unfinished_lead):
     got = duplicate_checker(order=not_paid_order)
 
-    assert got == not_paid_order
-    assert got.amocrm_lead == unfinished_lead
+    assert got == unfinished_lead.order
 
 
 def test_fails_if_many_lead_for_same_course_and_user(duplicate_checker, factory, not_paid_order):


### PR DESCRIPTION
Провел небольшой рефакторинг, чтобы AmoCRMOrderDuplicateChecker не имел сайд-эффект и в целом соответствовал SRP. Перелинковку для сделки и заказа делаю явно в таске теперь.