### PR TITLE
Replace sleep with countdown for courses and groups tasks

### DIFF
--- a/src/amocrm/tasks.py
+++ b/src/amocrm/tasks.py
@@ -133,7 +133,6 @@ def delete_order_from_amocrm(order_id: int) -> None:
     acks_late=True,
 )
 def push_product_groups() -> None:
-    time.sleep(1)  # avoid race condition when groups are not saved yet
     AmoCRMProductGroupsUpdater()()
 
 
@@ -147,8 +146,6 @@ def push_product_groups() -> None:
     acks_late=True,
 )
 def push_course(course_id: int) -> int:
-    time.sleep(1)  # avoid race condition when course is not saved yet
-
     course = apps.get_model("products.Course").objects.get(id=course_id)
     if hasattr(course, "amocrm_course"):
         return AmoCRMCourseUpdater(amocrm_course=course.amocrm_course)()

--- a/src/products/admin/course.py
+++ b/src/products/admin/course.py
@@ -96,4 +96,4 @@ class CourseAdmin(ModelAdmin):
         super().save_model(request, obj, form, change)
 
         if tasks.amocrm_enabled():
-            tasks.push_course.delay(course_id=obj.pk)
+            tasks.push_course.apply_async(kwargs={"course_id": obj.pk}, countdown=1)

--- a/src/products/admin/group.py
+++ b/src/products/admin/group.py
@@ -17,4 +17,4 @@ class GroupAdmin(ModelAdmin):
         super().save_model(request, obj, form, change)
 
         if tasks.amocrm_enabled():
-            tasks.push_product_groups.delay()
+            tasks.push_product_groups.apply_async(countdown=1)


### PR DESCRIPTION
Заменил sleep внутри таски на aplly_async + countdown. Т.к. эти таски также регулярно запускаются пачками для гарантии обновления, а в таком случае слип внутри таски просто блокирует воркера (а так как таких тасок по штуке на каждый курс, то это как минимум блок на 1,5 минуты). А вот для избежания race condition добавил countdown в местах, где запускается уже отдельная таска на конкретный объект