### PR TITLE
set amocrm_lead for old order None and after set lead to current order

### DIFF
--- a/src/amocrm/services/orders/order_pusher.py
+++ b/src/amocrm/services/orders/order_pusher.py
@@ -59,8 +59,11 @@ class AmoCRMOrderPusher(BaseService):
             return order_with_lead.amocrm_lead
 
     def link_existing_lead_to_current_order(self, existing_lead: AmoCRMOrderLead) -> None:
-        existing_lead.order = self.order
-        existing_lead.save()
+        old_order = existing_lead.order
+        old_order.amocrm_lead = None
+        old_order.save()
+        self.order.amocrm_lead = existing_lead
+        self.order.save()
 
     def order_must_be_pushed(self) -> bool:
         if self.order.is_b2b:

--- a/src/amocrm/tests/services/order/tests_order_pusher.py
+++ b/src/amocrm/tests/services/order/tests_order_pusher.py
@@ -90,7 +90,6 @@ def test_call_update_with_lead_returned(order_pusher, returned_order_with_lead, 
 def test_new_not_paid_order_linked_to_existing_lead_calls_update(order_pusher, not_paid_order_without_lead, mock_update_amocrm_lead, amocrm_lead):
     order_pusher(order=not_paid_order_without_lead)
 
-    not_paid_order_without_lead.amocrm_lead.refresh_from_db()
     assert not_paid_order_without_lead.amocrm_lead == amocrm_lead
     mock_update_amocrm_lead.assert_called_once_with(kwargs=dict(order_id=not_paid_order_without_lead.id), countdown=1)
 
@@ -104,7 +103,6 @@ def test_new_paid_order_linked_to_existing_lead_calls_update(
 ):
     order_pusher(order=paid_order_without_lead)
 
-    paid_order_without_lead.amocrm_lead.refresh_from_db()
     assert paid_order_without_lead.amocrm_lead == amocrm_lead
     mock_push_existing_order_to_amocrm.assert_called_once_with(kwargs=dict(order_id=paid_order_without_lead.id), countdown=1)
 
@@ -118,7 +116,6 @@ def test_new_order_linked_to_existing_lead_from_returned_order_calls_update(
 ):
     order_pusher(order=paid_order_without_lead)
 
-    paid_order_without_lead.amocrm_lead.refresh_from_db()
     mock_push_existing_order_to_amocrm.assert_called_once_with(kwargs=dict(order_id=paid_order_without_lead.id), countdown=1)
     assert paid_order_without_lead.amocrm_lead == amocrm_lead
 


### PR DESCRIPTION
Тут https://github.com/tough-dev-school/education-backend/pull/1899 пропустил баг из-за которого amocrm_lead по факту не переназначался в БД. В рамках транзакции отображался корректно, но при попадении в следующую таску там уже отсутствовала нужная связь.
Чтобы корректно менялась связь сделки и заказа, нужно сначала сохранить в старом заказе поле amocrm_lead = None, а только пото назначить текущему заказу актуальную сделку