### PR TITLE
Add test lead is linked to current order in child service

### DIFF
--- a/src/amocrm/tests/conftest.py
+++ b/src/amocrm/tests/conftest.py
@@ -16,11 +16,6 @@ def amocrm_user(factory, user):
 
 
 @pytest.fixture
-def amocrm_contact(factory, user):
-    return factory.amocrm_user_contact(user=user)
-
-
-@pytest.fixture
 def amocrm_course(factory, course):
     return factory.amocrm_course(course=course)
 

--- a/src/amocrm/tests/conftest.py
+++ b/src/amocrm/tests/conftest.py
@@ -16,6 +16,11 @@ def amocrm_user(factory, user):
 
 
 @pytest.fixture
+def amocrm_contact(factory, user):
+    return factory.amocrm_user_contact(user=user)
+
+
+@pytest.fixture
 def amocrm_course(factory, course):
     return factory.amocrm_course(course=course)
 

--- a/src/amocrm/tests/services/order/tests_order_pusher.py
+++ b/src/amocrm/tests/services/order/tests_order_pusher.py
@@ -35,11 +35,6 @@ def mock_push_order(mocker):
     return mocker.patch("amocrm.services.orders.order_pusher.AmoCRMOrderPusher.push_order")
 
 
-@pytest.fixture(autouse=True)
-def _amocrm_entities(amocrm_course, amocrm_user, amocrm_contact):
-    return
-
-
 @pytest.fixture
 def amocrm_lead(factory):
     return factory.amocrm_order_lead()

--- a/src/amocrm/tests/services/order/tests_order_pusher.py
+++ b/src/amocrm/tests/services/order/tests_order_pusher.py
@@ -153,12 +153,16 @@ def test_not_push_if_there_is_already_paid_order(not_paid_order_without_lead, mo
 
 @pytest.mark.usefixtures("not_paid_order_with_lead")
 def test_child_service_gets_order_with_linked_lead(not_paid_order_without_lead, amocrm_lead, mocker):
+    """
+    Поступил новый заказ, но есть аналогичный неоплаченный заказ с открытой сделкой -
+    сделка привязывается к новому заказу, и обновляется в Амо, чтобы была указана актуальная стоимость и время создания
+    """
     mock_updater_init = mocker.patch("amocrm.services.orders.order_lead_updater.AmoCRMOrderLeadUpdater.__init__", return_value=None)
     mock_update = mocker.patch("amocrm.services.orders.order_lead_updater.AmoCRMOrderLeadUpdater.__call__")
 
     AmoCRMOrderPusher(order=not_paid_order_without_lead)()
 
-    assert not_paid_order_without_lead.amocrm_lead == amocrm_lead
+    assert paid_order_without_lead.amocrm_lead == amocrm_lead
     mock_updater_init.assert_called_once_with(amocrm_lead=amocrm_lead)
     mock_update.assert_called_once()
 

--- a/src/amocrm/tests/services/order/tests_order_pusher.py
+++ b/src/amocrm/tests/services/order/tests_order_pusher.py
@@ -162,7 +162,7 @@ def test_child_service_gets_order_with_linked_lead(not_paid_order_without_lead, 
 
     AmoCRMOrderPusher(order=not_paid_order_without_lead)()
 
-    assert paid_order_without_lead.amocrm_lead == amocrm_lead
+    assert not_paid_order_without_lead.amocrm_lead == amocrm_lead
     mock_updater_init.assert_called_once_with(amocrm_lead=amocrm_lead)
     mock_update.assert_called_once()
 


### PR DESCRIPTION
Тест к https://github.com/tough-dev-school/education-backend/pull/1902#issuecomment-1693505366

Для моделирования бага сделал мок на уровень ниже, чтобы точно убедиться, что дочерний сервис инициализируется с прикрепленной сделкой

Баг как раз состоял в том, что сделка по факту не прикреплялась и [в сервис попадал None](https://f213.sentry.io/issues/4420416181/?project=1807512&query=&referrer=project-issue-stream) 