### PR TITLE
check if order should be returned in amocrm

### DIFF
--- a/src/amocrm/services/orders/order_returner.py
+++ b/src/amocrm/services/orders/order_returner.py
@@ -15,6 +15,17 @@ class AmoCRMOrderReturner(BaseService):
     order: Order
 
     def act(self) -> None:
+        if not self.order_must_be_returned():
+            return
+
         AmoCRMLead(order=self.order).update(status="closed")
         AmoCRMTransaction(order=self.order).delete()
         self.order.amocrm_transaction.delete()  # type: ignore
+
+    def order_must_be_returned(self) -> bool:
+        if self.order.is_b2b:
+            return False
+        if self.order.price == 0:
+            return False
+
+        return True

--- a/src/amocrm/services/orders/order_returner.py
+++ b/src/amocrm/services/orders/order_returner.py
@@ -13,7 +13,7 @@ class AmoCRMOrderReturner(BaseService):
     order: Order
 
     def act(self) -> None:
-        if self.order.amocrm_transaction is None:
+        if self.order.amocrm_transaction is None:  # order is not pushed to amocrm as purchased
             return
 
         AmoCRMLead(order=self.order).update(status="closed")

--- a/src/amocrm/services/orders/order_returner.py
+++ b/src/amocrm/services/orders/order_returner.py
@@ -8,24 +8,14 @@ from orders.models import Order
 
 @dataclass
 class AmoCRMOrderReturner(BaseService):
-    """
-    Updates amocrm_lead for given order and deletes transaction
-    """
+    """Updates amocrm_lead for given order and deletes transaction"""
 
     order: Order
 
     def act(self) -> None:
-        if not self.order_must_be_returned():
+        if self.order.amocrm_transaction is None:
             return
 
         AmoCRMLead(order=self.order).update(status="closed")
         AmoCRMTransaction(order=self.order).delete()
-        self.order.amocrm_transaction.delete()  # type: ignore
-
-    def order_must_be_returned(self) -> bool:
-        if self.order.is_b2b:
-            return False
-        if self.order.price == 0:
-            return False
-
-        return True
+        self.order.amocrm_transaction.delete()

--- a/src/amocrm/tests/services/order/conftest.py
+++ b/src/amocrm/tests/services/order/conftest.py
@@ -16,3 +16,8 @@ def amocrm_lead(mixer, order):
 @pytest.fixture
 def paid_order_with_lead(user, course, factory, amocrm_lead):
     return factory.order(user=user, course=course, is_paid=True, author=user, amocrm_lead=amocrm_lead)
+
+
+@pytest.fixture
+def paid_order_without_lead(user, course, factory):
+    return factory.order(user=user, course=course, is_paid=True, author=user)

--- a/src/amocrm/tests/services/order/tests_order_pusher.py
+++ b/src/amocrm/tests/services/order/tests_order_pusher.py
@@ -40,11 +40,6 @@ def mock_push_order(mocker):
 
 
 @pytest.fixture
-def paid_order_without_lead(user, course, factory):
-    return factory.order(user=user, course=course, is_paid=True, author=user)
-
-
-@pytest.fixture
 def not_paid_order_without_lead(factory, user, course):
     return factory.order(user=user, course=course, is_paid=False, author=user)
 

--- a/src/amocrm/tests/services/order/tests_order_returner.py
+++ b/src/amocrm/tests/services/order/tests_order_returner.py
@@ -26,18 +26,46 @@ def unpaid_order(mixer, paid_order_with_lead):
 
 
 @pytest.fixture
-def order_deleter():
+def unpaid_b2b_order(paid_order_without_lead, another_user):
+    paid_order_without_lead.set_not_paid()
+    paid_order_without_lead.setattr_and_save("author", another_user)
+    return paid_order_without_lead
+
+
+@pytest.fixture
+def unpaid_free_order(paid_order_without_lead):
+    paid_order_without_lead.set_not_paid()
+    paid_order_without_lead.setattr_and_save("price", 0)
+    return paid_order_without_lead
+
+
+@pytest.fixture
+def order_returner():
     return lambda order: AmoCRMOrderReturner(order=order)()
 
 
-def test_correct_calls(order_deleter, unpaid_order, mock_update_lead, mock_delete_transaction):
-    order_deleter(unpaid_order)
+def test_correct_calls(order_returner, unpaid_order, mock_update_lead, mock_delete_transaction):
+    order_returner(unpaid_order)
 
     mock_update_lead.assert_called_once_with(status="closed")
     mock_delete_transaction.assert_called_once()
 
 
-def test_delete_transaction(order_deleter, unpaid_order, mock_update_lead, mock_delete_transaction):
-    order_deleter(unpaid_order)
+def test_delete_transaction(order_returner, unpaid_order, mock_update_lead, mock_delete_transaction):
+    order_returner(unpaid_order)
 
     assert AmoCRMOrderTransaction.objects.count() == 0
+
+
+def test_dont_return_if_b2b(order_returner, unpaid_b2b_order, mock_update_lead, mock_delete_transaction):
+    order_returner(unpaid_b2b_order)
+
+    mock_update_lead.assert_not_called()
+    mock_delete_transaction.assert_not_called()
+
+
+def test_dont_return_if_free(order_returner, unpaid_free_order, mock_update_lead, mock_delete_transaction):
+    order_returner(unpaid_free_order)
+
+    mock_update_lead.assert_not_called()
+    mock_delete_transaction.assert_not_called()

--- a/src/amocrm/tests/services/order/tests_order_returner.py
+++ b/src/amocrm/tests/services/order/tests_order_returner.py
@@ -26,16 +26,8 @@ def unpaid_order(mixer, paid_order_with_lead):
 
 
 @pytest.fixture
-def unpaid_b2b_order(paid_order_without_lead, another_user):
+def unpaid_order_not_in_amo(paid_order_without_lead):
     paid_order_without_lead.set_not_paid()
-    paid_order_without_lead.setattr_and_save("author", another_user)
-    return paid_order_without_lead
-
-
-@pytest.fixture
-def unpaid_free_order(paid_order_without_lead):
-    paid_order_without_lead.set_not_paid()
-    paid_order_without_lead.setattr_and_save("price", 0)
     return paid_order_without_lead
 
 
@@ -57,15 +49,8 @@ def test_delete_transaction(order_returner, unpaid_order, mock_update_lead, mock
     assert AmoCRMOrderTransaction.objects.count() == 0
 
 
-def test_dont_return_if_b2b(order_returner, unpaid_b2b_order, mock_update_lead, mock_delete_transaction):
-    order_returner(unpaid_b2b_order)
-
-    mock_update_lead.assert_not_called()
-    mock_delete_transaction.assert_not_called()
-
-
-def test_dont_return_if_free(order_returner, unpaid_free_order, mock_update_lead, mock_delete_transaction):
-    order_returner(unpaid_free_order)
+def test_dont_return_if_not_in_amo(order_returner, unpaid_order_not_in_amo, mock_update_lead, mock_delete_transaction):
+    order_returner(unpaid_order_not_in_amo)
 
     mock_update_lead.assert_not_called()
     mock_delete_transaction.assert_not_called()


### PR DESCRIPTION
Фиск к https://github.com/tough-dev-school/education-backend/issues/1951

Получили ошибку, когда сделали возврат b2b заказа. Т.к. такие заказы не отправляются в амо, то у них нет никаких связанных сущностей.
Добавил проверку внутрь OrderReturner на то, что:

1. Заказ не b2b
2. Заказ не бесплатный 

Возможно,проверка на бесплатность даже излишня, но и про возврат b2b заказов я изначально также думал, поэтому оставил проверку на бесплатность. Думаю, может быть кейс, когда кому-то выдали промокод на бесплатное прохождение курса, а потом по какой-то причине сделали возврат такой покупки. 