### PR TITLE
Drop pytest httpx for respx

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -268,7 +268,6 @@ httpx[http2]==0.24.1
     # via
     #   education-backend (pyproject.toml)
     #   httpx-cache
-    #   pytest-httpx
     #   respx
 httpx-cache[redis]==0.12.0
     # via education-backend (pyproject.toml)
@@ -374,7 +373,6 @@ pytest==7.4.2
     #   pytest-django
     #   pytest-env
     #   pytest-freezegun
-    #   pytest-httpx
     #   pytest-mock
     #   pytest-randomly
     #   pytest-repeat
@@ -388,8 +386,6 @@ pytest-django==4.5.2
 pytest-env==1.0.1
     # via education-backend (pyproject.toml)
 pytest-freezegun==0.4.2
-    # via education-backend (pyproject.toml)
-pytest-httpx==0.24.0
     # via education-backend (pyproject.toml)
 pytest-mock==3.11.1
     # via education-backend (pyproject.toml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ dev = [
     "pytest-randomly",
     "pytest-repeat",
     "pytest-xdist",
-    "pytest-httpx",
     "respx",
 
     "freezegun",

--- a/src/amocrm/tests/http/tests_http.py
+++ b/src/amocrm/tests/http/tests_http.py
@@ -59,16 +59,16 @@ def test_request_has_authorization_header(method, token, mocker):
     )
 
 
-def test_get_ok(httpx_mock):
-    httpx_mock.add_response(url="https://test.amocrm.ru/api/v4/companies?limit=100500", method="GET", json={"ok": True})
+def test_get_ok(respx_mock):
+    respx_mock.get(url="https://test.amocrm.ru/api/v4/companies?limit=100500").respond(json={"ok": True})
 
     got = http.get("api/v4/companies", params={"limit": 100500})
 
     assert "ok" in got
 
 
-def test_get_ok_with_expected_status_code(httpx_mock):
-    httpx_mock.add_response(url="https://test.amocrm.ru/api/v4/companies?limit=100500", method="GET", json={"ok": True}, status_code=321)
+def test_get_ok_with_expected_status_code(respx_mock):
+    respx_mock.get(url="https://test.amocrm.ru/api/v4/companies?limit=100500").respond(json={"ok": True}, status_code=321)
     got = http.get("api/v4/companies", expected_status_codes=[321], params={"limit": 100500})
 
     assert "ok" in got
@@ -84,16 +84,16 @@ def test_get_cached(respx_mock):
     assert "ok" in got  # client used cached value and didn't fail with 500
 
 
-def test_delete_ok(httpx_mock):
-    httpx_mock.add_response(url="https://test.amocrm.ru/api/v4/transactions/444", method="DELETE")
+def test_delete_ok(respx_mock):
+    respx_mock.delete(url="https://test.amocrm.ru/api/v4/transactions/444")
 
     got = http.delete("api/v4/transactions/444")
 
     assert got == {}
 
 
-def test_delete_ok_with_expected_status_code(httpx_mock):
-    httpx_mock.add_response(url="https://test.amocrm.ru/api/v4/transactions/444", method="DELETE", status_code=321)
+def test_delete_ok_with_expected_status_code(respx_mock):
+    respx_mock.delete(url="https://test.amocrm.ru/api/v4/transactions/444").respond(status_code=321)
 
     got = http.delete("api/v4/transactions/444", expected_status_codes=[321])
 
@@ -101,8 +101,8 @@ def test_delete_ok_with_expected_status_code(httpx_mock):
 
 
 @pytest.mark.parametrize("method", ["post", "patch"])
-def test_request_ok(httpx_mock, method):
-    httpx_mock.add_response(url="https://test.amocrm.ru/api/v4/companies", method=method, json={"ok": True})
+def test_request_ok(respx_mock, method):
+    getattr(respx_mock, method)(url="https://test.amocrm.ru/api/v4/companies").respond(json={"ok": True})
     request = getattr(http, method)
 
     got = request("api/v4/companies", {})
@@ -111,8 +111,8 @@ def test_request_ok(httpx_mock, method):
 
 
 @pytest.mark.parametrize("method", ["post", "patch"])
-def test_ok_with_expected_status_code(httpx_mock, method):
-    httpx_mock.add_response(url="https://test.amocrm.ru/api/v4/companies", json={"ok": True}, method=method, status_code=100500)
+def test_ok_with_expected_status_code(respx_mock, method):
+    getattr(respx_mock, method)(url="https://test.amocrm.ru/api/v4/companies").respond(json={"ok": True}, status_code=100500)
     request = getattr(http, method)
 
     got = request("api/v4/companies", {}, expected_status_codes=[100500])
@@ -121,8 +121,8 @@ def test_ok_with_expected_status_code(httpx_mock, method):
 
 
 @pytest.mark.parametrize("method", ["post", "patch"])
-def test_request_fail(httpx_mock, method):
-    httpx_mock.add_response(url="https://test.amocrm.ru/api/v4/companies", method=method, status_code=210)
+def test_request_fail(respx_mock, method):
+    getattr(respx_mock, method)(url="https://test.amocrm.ru/api/v4/companies").respond(status_code=210)
     request = getattr(http, method)
 
     with pytest.raises(AmoCRMClientException, match="Non-ok HTTP response from amocrm: 210"):
@@ -130,8 +130,8 @@ def test_request_fail(httpx_mock, method):
 
 
 @pytest.mark.parametrize("method", ["post", "patch"])
-def test_request_fail_with_body(httpx_mock, method):
-    httpx_mock.add_response(url="https://test.amocrm.ru/api/v4/companies", method=method, status_code=210, json={"info": "damn we lost"})
+def test_request_fail_with_body(respx_mock, method):
+    getattr(respx_mock, method)(url="https://test.amocrm.ru/api/v4/companies").respond(status_code=210, json={"info": "damn we lost"})
     request = getattr(http, method)
 
     with pytest.raises(AmoCRMClientException, match="Non-ok HTTP response from amocrm: 210\nResponse data: {'info': 'damn we lost'}"):
@@ -139,12 +139,8 @@ def test_request_fail_with_body(httpx_mock, method):
 
 
 @pytest.mark.parametrize("method", ["post", "patch"])
-def test_request_fail_because_of_errors_in_response(httpx_mock, method):
-    httpx_mock.add_response(
-        url="https://test.amocrm.ru/api/v4/companies",
-        method=method,
-        json={"_embedded": {"errors": [["All my life is an error"]]}},
-    )
+def test_request_fail_because_of_errors_in_response(respx_mock, method):
+    getattr(respx_mock, method)(url="https://test.amocrm.ru/api/v4/companies").respond(json={"_embedded": {"errors": [["All my life is an error"]]}})
     request = getattr(http, method)
 
     with pytest.raises(AmoCRMClientException, match="Errors in response to https://test.amocrm.ru/api/v4/companies:"):

--- a/src/app/tests/dashamail/conftest.py
+++ b/src/app/tests/dashamail/conftest.py
@@ -21,7 +21,7 @@ def _set_dashamail_credentials(settings):
 @pytest.fixture
 def dashamail(respx_mock: MockRouter):
     client = AppDashamail()
-    client.respx_mock = respx_mock
+    client.respx_mock = respx_mock  # type: ignore
     return client
 
 

--- a/src/app/tests/dashamail/conftest.py
+++ b/src/app/tests/dashamail/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+from respx import MockRouter
+
 from app.integrations.dashamail import AppDashamail
 
 pytestmark = [pytest.mark.django_db]
@@ -17,7 +19,7 @@ def _set_dashamail_credentials(settings):
 
 
 @pytest.fixture
-def dashamail(respx_mock):
+def dashamail(respx_mock: MockRouter):
     client = AppDashamail()
     client.respx_mock = respx_mock
     return client

--- a/src/app/tests/dashamail/conftest.py
+++ b/src/app/tests/dashamail/conftest.py
@@ -17,9 +17,9 @@ def _set_dashamail_credentials(settings):
 
 
 @pytest.fixture
-def dashamail(httpx_mock):
+def dashamail(respx_mock):
     client = AppDashamail()
-    client.httpx_mock = httpx_mock
+    client.respx_mock = respx_mock
     return client
 
 

--- a/src/app/tests/dashamail/tests_dashamail_get_subscriber.py
+++ b/src/app/tests/dashamail/tests_dashamail_get_subscriber.py
@@ -43,7 +43,7 @@ def test_get_subscriber_with_yandex_mail(dashamail, post, user, email, expected_
 
 
 def test_get_subscriber_correct_values(dashamail, user, successful_response_json):
-    dashamail.httpx_mock.add_response(url="https://api.dashamail.com", method="POST", json=successful_response_json)
+    dashamail.respx_mock.post(url="https://api.dashamail.com").respond(json=successful_response_json)
 
     member_id, is_active = dashamail.get_subscriber(
         email=user.email,
@@ -54,7 +54,7 @@ def test_get_subscriber_correct_values(dashamail, user, successful_response_json
 
 
 def test_get_subscriber_error_doesnt_exist(dashamail, user, fail_response_json):
-    dashamail.httpx_mock.add_response(url="https://api.dashamail.com", method="POST", json=fail_response_json)
+    dashamail.respx_mock.post(url="https://api.dashamail.com").respond(json=fail_response_json)
 
     member_id, is_active = dashamail.get_subscriber(
         email=user.email,

--- a/src/app/tests/dashamail/tests_dashamail_http.py
+++ b/src/app/tests/dashamail/tests_dashamail_http.py
@@ -6,27 +6,26 @@ pytestmark = [pytest.mark.django_db]
 
 
 def test_post_ok(dashamail, successful_response_json):
-    dashamail.httpx_mock.add_response(url="https://api.dashamail.com", method="POST", json=successful_response_json)
+    dashamail.respx_mock.post(url="https://api.dashamail.com").respond(json=successful_response_json)
 
     assert dashamail.http.post("", payload={}) == successful_response_json
 
 
 def test_post_no_content(dashamail):
-    dashamail.httpx_mock.add_response(url="https://api.dashamail.com/test/", method="POST")
-
+    dashamail.respx_mock.post(url="https://api.dashamail.com/test/")
     with pytest.raises(DashamailWrongResponse):
         assert dashamail.http.post("test/", payload={})
 
 
 def test_post_wrong_status_code(dashamail, successful_response_json):
-    dashamail.httpx_mock.add_response(url="https://api.dashamail.com/test/", method="POST", json=successful_response_json, status_code=500)
+    dashamail.respx_mock.post(url="https://api.dashamail.com/test/").respond(json=successful_response_json, status_code=500)
 
     with pytest.raises(DashamailWrongResponse):
         dashamail.http.post("test/", payload={})
 
 
 def test_post_payload(dashamail, successful_response_json):
-    dashamail.httpx_mock.add_response(url="https://api.dashamail.com/test/", method="POST", json=successful_response_json)
+    dashamail.respx_mock.post(url="https://api.dashamail.com/test/").respond(json=successful_response_json)
 
     dashamail.http.post(
         "test/",
@@ -35,12 +34,12 @@ def test_post_payload(dashamail, successful_response_json):
         },
     )
 
-    assert b"test=test" in dashamail.httpx_mock.get_request().content
+    assert b"test=test" in dashamail.respx_mock.calls.last.request.content
 
 
 def test_api_key_in_payload(dashamail, successful_response_json):
-    dashamail.httpx_mock.add_response(url="https://api.dashamail.com/test/", method="POST", json=successful_response_json)
+    dashamail.respx_mock.post(url="https://api.dashamail.com/test/").respond(json=successful_response_json)
 
     dashamail.http.post("test/", payload={})
 
-    assert b"api_key=apikey" in dashamail.httpx_mock.get_request().content
+    assert b"api_key=apikey" in dashamail.respx_mock.calls.last.request.content

--- a/src/app/tests/dashamail/tests_dashamail_subscribe.py
+++ b/src/app/tests/dashamail/tests_dashamail_subscribe.py
@@ -34,7 +34,7 @@ def test_subscribe(dashamail, post, user, tags, request_tags):
 
 
 def test_subscription_failed(dashamail, user, fail_response_json):
-    dashamail.httpx_mock.add_response(url="https://api.dashamail.com", method="POST", json=fail_response_json)
+    dashamail.respx_mock.post(url="https://api.dashamail.com").respond(json=fail_response_json)
 
     with pytest.raises(DashamailSubscriptionFailed):
         dashamail.subscribe_user(

--- a/src/app/tests/dashamail/tests_dashamail_update_subscriber.py
+++ b/src/app/tests/dashamail/tests_dashamail_update_subscriber.py
@@ -34,7 +34,7 @@ def test_update_subscriber(dashamail, post, user, tags, request_tags):
 
 
 def test_subscription_failed(dashamail, user, fail_response_json):
-    dashamail.httpx_mock.add_response(url="https://api.dashamail.com", method="POST", json=fail_response_json)
+    dashamail.respx_mock.post(url="https://api.dashamail.com").respond(json=fail_response_json)
 
     with pytest.raises(DashamailUpdateFailed):
         dashamail.update_subscriber(

--- a/src/banking/tests/atol/test_atol_auth.py
+++ b/src/banking/tests/atol/test_atol_auth.py
@@ -16,23 +16,21 @@ def fetch(mocker):
     return mocker.patch("banking.atol.auth.fetch", return_value="secret")
 
 
-def test_ok(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(
-        url="https://online.atol.ru/possystem/v4/getToken",
+def test_ok(respx_mock):
+    respx_mock.route(url="https://online.atol.ru/possystem/v4/getToken").respond(
         json={
             "error": None,
             "token": "__mocked",
             "timestamp": "30.11.2017 17:58:53",  # this the real timestamp from official docs
-        },
+        }
     )
 
     assert auth.get_atol_token() == "__mocked"
 
 
 @pytest.mark.parametrize("status_code", [200, 400, 500])
-def test_400(httpx_mock: HTTPXMock, status_code):
-    httpx_mock.add_response(
-        url="https://online.atol.ru/possystem/v4/getToken",
+def test_400(respx_mock, status_code):
+    respx_mock.route(url="https://online.atol.ru/possystem/v4/getToken").respond(
         status_code=status_code,
         json={
             "error": {

--- a/src/banking/tests/atol/test_atol_auth.py
+++ b/src/banking/tests/atol/test_atol_auth.py
@@ -1,7 +1,5 @@
 import pytest
 
-from pytest_httpx import HTTPXMock
-
 from banking.atol import auth
 from banking.atol import exceptions
 

--- a/src/banking/tests/atol/test_atol_auth.py
+++ b/src/banking/tests/atol/test_atol_auth.py
@@ -1,5 +1,7 @@
 import pytest
 
+from respx import MockRouter
+
 from banking.atol import auth
 from banking.atol import exceptions
 
@@ -14,7 +16,7 @@ def fetch(mocker):
     return mocker.patch("banking.atol.auth.fetch", return_value="secret")
 
 
-def test_ok(respx_mock):
+def test_ok(respx_mock: MockRouter):
     respx_mock.route(url="https://online.atol.ru/possystem/v4/getToken").respond(
         json={
             "error": None,
@@ -27,7 +29,7 @@ def test_ok(respx_mock):
 
 
 @pytest.mark.parametrize("status_code", [200, 400, 500])
-def test_400(respx_mock, status_code):
+def test_400(respx_mock: MockRouter, status_code):
     respx_mock.route(url="https://online.atol.ru/possystem/v4/getToken").respond(
         status_code=status_code,
         json={

--- a/src/diplomas/tests/diploma_generator/tests_diploma_generator_functional.py
+++ b/src/diplomas/tests/diploma_generator/tests_diploma_generator_functional.py
@@ -9,8 +9,8 @@ pytestmark = [
 
 
 @pytest.fixture(autouse=True)
-def _mock_response(httpx_mock):
-    httpx_mock.add_response(content=b"TYPICAL MAC USER JPG")
+def _mock_response(respx_mock):
+    respx_mock.route().respond(content=b"TYPICAL MAC USER JPG")
 
 
 def test_service(generator, student, course):

--- a/src/diplomas/tests/diploma_generator/tests_diploma_generator_functional.py
+++ b/src/diplomas/tests/diploma_generator/tests_diploma_generator_functional.py
@@ -1,5 +1,7 @@
 import pytest
 
+from respx import MockRouter
+
 from diplomas.models import Diploma
 from diplomas.tasks import generate_diploma
 
@@ -9,7 +11,7 @@ pytestmark = [
 
 
 @pytest.fixture(autouse=True)
-def _mock_response(respx_mock):
+def _mock_response(respx_mock: MockRouter):
     respx_mock.route().respond(content=b"TYPICAL MAC USER JPG")
 
 

--- a/src/diplomas/tests/diploma_generator/tests_diploma_generator_retry.py
+++ b/src/diplomas/tests/diploma_generator/tests_diploma_generator_retry.py
@@ -1,6 +1,7 @@
 import pytest
 
 import httpx
+from respx import MockRouter
 
 from diplomas.services.diploma_generator import WrongDiplomaServiceResponse
 
@@ -38,7 +39,7 @@ def generator(generator):
     return generator(language="RU")
 
 
-def test_ok(generator, respx_mock):
+def test_ok(generator, respx_mock: MockRouter):
     respx_mock.route().mock(side_effect=generate_exception_n_times(3))
 
     diploma = generator()
@@ -46,7 +47,7 @@ def test_ok(generator, respx_mock):
     assert diploma.image.read() == b"TYPICAL MAC USER JPG"
 
 
-def test_fail(generator, respx_mock):
+def test_fail(generator, respx_mock: MockRouter):
     respx_mock.route().mock(side_effect=generate_exception_n_times(6))
 
     with pytest.raises(WrongDiplomaServiceResponse):

--- a/src/diplomas/tests/diploma_generator/tests_diploma_generator_retry.py
+++ b/src/diplomas/tests/diploma_generator/tests_diploma_generator_retry.py
@@ -38,16 +38,16 @@ def generator(generator):
     return generator(language="RU")
 
 
-def test_ok(generator, httpx_mock):
-    httpx_mock.add_callback(generate_exception_n_times(3))
+def test_ok(generator, respx_mock):
+    respx_mock.route().mock(side_effect=generate_exception_n_times(3))
 
     diploma = generator()
 
     assert diploma.image.read() == b"TYPICAL MAC USER JPG"
 
 
-def test_fail(generator, httpx_mock):
-    httpx_mock.add_callback(generate_exception_n_times(6))
+def test_fail(generator, respx_mock):
+    respx_mock.route().mock(side_effect=generate_exception_n_times(6))
 
     with pytest.raises(WrongDiplomaServiceResponse):
         generator()

--- a/src/notion/tests/api/test_notion_cache_api.py
+++ b/src/notion/tests/api/test_notion_cache_api.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pytest_httpx import HTTPXMock
+from respx import MockRouter
 
 from app.test.api_client import DRFClient
 from notion.models import NotionCacheEntry
@@ -22,9 +22,8 @@ def assert_all_responses_were_requested() -> bool:
 
 
 @pytest.fixture(autouse=True)
-def _ok(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(
-        url="http://notion.middleware/v1/notion/loadPageChunk/",
+def _ok(respx_mock: MockRouter):
+    respx_mock.route(url="http://notion.middleware/v1/notion/loadPageChunk/").respond(
         json={
             "recordMap": {
                 "__version__": 3,
@@ -55,37 +54,37 @@ def mock_blocks_fetching(mocker):
     return mocker.patch("notion.block.NotionBlockList.get_underlying_block_ids", return_value=[])
 
 
-def test_request_is_done_for_the_first_time(api, httpx_mock: HTTPXMock):
+def test_request_is_done_for_the_first_time(api, respx_mock: MockRouter):
     api.get("/api/v2/notion/materials/0e5693d2173a4f77ae8106813b6e5329/")
 
-    assert len(httpx_mock.get_requests()) == 1
+    assert len(respx_mock.calls) == 1
 
 
-def test_request_is_cached(api, httpx_mock: HTTPXMock):
+def test_request_is_cached(api, respx_mock: MockRouter):
     api.get("/api/v2/notion/materials/0e5693d2173a4f77ae8106813b6e5329/")
     api.get("/api/v2/notion/materials/0e5693d2173a4f77ae8106813b6e5329/")
 
-    assert len(httpx_mock.get_requests()) == 1
+    assert len(respx_mock.calls) == 1
 
 
-def test_request_is_cached_in_notion_cache_model(api, httpx_mock: HTTPXMock):
+def test_request_is_cached_in_notion_cache_model(api, respx_mock: MockRouter):
     api.get("/api/v2/notion/materials/0e5693d2173a4f77ae8106813b6e5329/")
     NotionCacheEntry.objects.all().delete()
     api.get("/api/v2/notion/materials/0e5693d2173a4f77ae8106813b6e5329/")
 
-    assert len(httpx_mock.get_requests()) == 2
+    assert len(respx_mock.calls) == 2
 
 
-def test_staff_request_returns_uncached_page(api, as_staff, httpx_mock: HTTPXMock):
+def test_staff_request_returns_uncached_page(api, as_staff, respx_mock: MockRouter):
     api.get("/api/v2/notion/materials/0e5693d2173a4f77ae8106813b6e5329/")
     as_staff.get("/api/v2/notion/materials/0e5693d2173a4f77ae8106813b6e5329/")
 
-    assert len(httpx_mock.get_requests()) == 2
+    assert len(respx_mock.calls) == 2
 
 
-def test_staff_request_sets_cache(api, as_staff, httpx_mock: HTTPXMock):
+def test_staff_request_sets_cache(api, as_staff, respx_mock: MockRouter):
     api.get("/api/v2/notion/materials/0e5693d2173a4f77ae8106813b6e5329/")
     as_staff.get("/api/v2/notion/materials/0e5693d2173a4f77ae8106813b6e5329/")
     api.get("/api/v2/notion/materials/0e5693d2173a4f77ae8106813b6e5329/")  # should not be called
 
-    assert len(httpx_mock.get_requests()) == 2
+    assert len(respx_mock.calls) == 2

--- a/src/notion/tests/api/test_notion_cache_api.py
+++ b/src/notion/tests/api/test_notion_cache_api.py
@@ -16,11 +16,6 @@ def as_staff(staff_user):
     return DRFClient(user=staff_user)
 
 
-@pytest.fixture
-def assert_all_responses_were_requested() -> bool:
-    return False
-
-
 @pytest.fixture(autouse=True)
 def _ok(respx_mock: MockRouter):
     respx_mock.route(url="http://notion.middleware/v1/notion/loadPageChunk/").respond(

--- a/src/notion/tests/test_fetch_blocks.py
+++ b/src/notion/tests/test_fetch_blocks.py
@@ -1,12 +1,11 @@
 import pytest
 
-from pytest_httpx import HTTPXMock
+from respx import MockRouter
 
 
 @pytest.fixture
-def _ok(httpx_mock: HTTPXMock):
-    httpx_mock.add_response(
-        url="http://notion.middleware/v1/notion/syncRecordValues/",
+def _ok(respx_mock: MockRouter):
+    respx_mock.route(url="http://notion.middleware/v1/notion/syncRecordValues/").respond(
         json={
             "recordMap": {
                 "block": {

--- a/src/notion/tests/test_fetch_page.py
+++ b/src/notion/tests/test_fetch_page.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pytest_httpx import HTTPXMock
+from respx import MockRouter
 
 from notion.exceptions import NotionResponseError
 from notion.exceptions import NotSharedForWeb
@@ -36,8 +36,8 @@ def ok():
     }
 
 
-def test_ok(httpx_mock: HTTPXMock, ok, notion):
-    httpx_mock.add_response(url="http://notion.middleware/v1/notion/loadPageChunk/", json=ok)
+def test_ok(respx_mock: MockRouter, ok, notion):
+    respx_mock.route(url="http://notion.middleware/v1/notion/loadPageChunk/").respond(json=ok)
 
     page = notion.fetch_page("0cb348b3a2d24c05bc944e2302fa553")
 
@@ -45,16 +45,16 @@ def test_ok(httpx_mock: HTTPXMock, ok, notion):
     assert page.blocks[0].id == "first-block"
 
 
-def test_page_title(httpx_mock: HTTPXMock, ok, notion):
-    httpx_mock.add_response(url="http://notion.middleware/v1/notion/loadPageChunk/", json=ok)
+def test_page_title(respx_mock: MockRouter, ok, notion):
+    respx_mock.route(url="http://notion.middleware/v1/notion/loadPageChunk/").respond(json=ok)
 
     page = notion.fetch_page("0cb348b3a2d24c05bc944e2302fa553")
 
     assert page.title == "Неделя 1 из 4"
 
 
-def test_abscense_of_the_page_block_does_not_break_page_title(httpx_mock: HTTPXMock, ok, notion):
-    httpx_mock.add_response(url="http://notion.middleware/v1/notion/loadPageChunk/", json=ok)
+def test_abscense_of_the_page_block_does_not_break_page_title(respx_mock: MockRouter, ok, notion):
+    respx_mock.route(url="http://notion.middleware/v1/notion/loadPageChunk/").respond(json=ok)
 
     page = notion.fetch_page("0cb348b3a2d24c05bc944e2302fa553")
 
@@ -63,8 +63,8 @@ def test_abscense_of_the_page_block_does_not_break_page_title(httpx_mock: HTTPXM
     assert page.title is None
 
 
-def test_block_without_title_does_not_break_page_title_1(httpx_mock: HTTPXMock, ok, notion):
-    httpx_mock.add_response(url="http://notion.middleware/v1/notion/loadPageChunk/", json=ok)
+def test_block_without_title_does_not_break_page_title_1(respx_mock: MockRouter, ok, notion):
+    respx_mock.route(url="http://notion.middleware/v1/notion/loadPageChunk/").respond(json=ok)
 
     page = notion.fetch_page("0cb348b3a2d24c05bc944e2302fa553")
 
@@ -73,8 +73,8 @@ def test_block_without_title_does_not_break_page_title_1(httpx_mock: HTTPXMock, 
     assert page.title is None
 
 
-def test_block_without_title_does_not_break_page_title_2(httpx_mock: HTTPXMock, ok, notion):
-    httpx_mock.add_response(url="http://notion.middleware/v1/notion/loadPageChunk/", json=ok)
+def test_block_without_title_does_not_break_page_title_2(respx_mock: MockRouter, ok, notion):
+    respx_mock.route(url="http://notion.middleware/v1/notion/loadPageChunk/").respond(json=ok)
 
     page = notion.fetch_page("0cb348b3a2d24c05bc944e2302fa553")
 
@@ -83,9 +83,8 @@ def test_block_without_title_does_not_break_page_title_2(httpx_mock: HTTPXMock, 
     assert page.title is None
 
 
-def test_not_shared_exception(notion, httpx_mock: HTTPXMock):
-    httpx_mock.add_response(
-        url="http://notion.middleware/v1/notion/loadPageChunk/",
+def test_not_shared_exception(notion, respx_mock: MockRouter):
+    respx_mock.route(url="http://notion.middleware/v1/notion/loadPageChunk/").respond(
         json={
             "recordMap": {},  # not shared page looks excactly like this
         },
@@ -94,9 +93,8 @@ def test_not_shared_exception(notion, httpx_mock: HTTPXMock):
         notion.fetch_page("0cb348b3a2d24c05bc944e2302fa553")
 
 
-def test_wrong_response_exception(notion, httpx_mock: HTTPXMock):
-    httpx_mock.add_response(
-        url="http://notion.middleware/v1/notion/loadPageChunk/",
+def test_wrong_response_exception(notion, respx_mock: MockRouter):
+    respx_mock.route(url="http://notion.middleware/v1/notion/loadPageChunk/").respond(
         json={"errorId": "de586d84-7fbb-466b-b633-8b1ae5cf0497", "name": "ValidationError", "message": "Invalid input."},
     )
     with pytest.raises(NotionResponseError):

--- a/src/tinkoff/tests/dolyame_client/test_dolyame_commit.py
+++ b/src/tinkoff/tests/dolyame_client/test_dolyame_commit.py
@@ -2,6 +2,8 @@ import json
 import pytest
 import uuid
 
+from respx import MockRouter
+
 from tinkoff import tasks
 
 pytestmark = [pytest.mark.django_db]
@@ -12,7 +14,7 @@ def idempotency_key() -> str:
     return str(uuid.uuid4())
 
 
-def test(order, idempotency_key, respx_mock):
+def test(order, idempotency_key, respx_mock: MockRouter):
     respx_mock.route(
         url=f"https://partner.dolyame.ru/v1/orders/{order.slug}/commit",
         headers={
@@ -30,7 +32,7 @@ def test(order, idempotency_key, respx_mock):
 
 
 @pytest.mark.xfail(strict=True, reason="Just to make sure above code works")
-def test_header(order, idempotency_key, respx_mock):
+def test_header(order, idempotency_key, respx_mock: MockRouter):
     respx_mock.route(
         url=f"https://partner.dolyame.ru/v1/orders/{order.slug}/commit",
         headers={

--- a/src/tinkoff/tests/dolyame_client/test_dolyame_commit.py
+++ b/src/tinkoff/tests/dolyame_client/test_dolyame_commit.py
@@ -2,8 +2,6 @@ import json
 import pytest
 import uuid
 
-from pytest_httpx import HTTPXMock
-
 from tinkoff import tasks
 
 pytestmark = [pytest.mark.django_db]
@@ -14,17 +12,16 @@ def idempotency_key() -> str:
     return str(uuid.uuid4())
 
 
-def test(order, idempotency_key, httpx_mock: HTTPXMock):
-    httpx_mock.add_response(
+def test(order, idempotency_key, respx_mock):
+    respx_mock.route(
         url=f"https://partner.dolyame.ru/v1/orders/{order.slug}/commit",
-        match_headers={
+        headers={
             "X-Correlation-ID": idempotency_key,
         },
-        json={},
-    )
+    ).respond(json={})
 
     tasks.commit_dolyame_order(order_id=order.id, idempotency_key=idempotency_key)
-    result = json.loads(httpx_mock.get_requests()[0].content)
+    result = json.loads(respx_mock.calls.last.request.content)
 
     assert result["amount"] == "100500"
     assert result["items"][0]["name"] == "Предоставление доступа к записи курса «Пентакли и Тентакли»"
@@ -33,13 +30,12 @@ def test(order, idempotency_key, httpx_mock: HTTPXMock):
 
 
 @pytest.mark.xfail(strict=True, reason="Just to make sure above code works")
-def test_header(order, idempotency_key, httpx_mock: HTTPXMock):
-    httpx_mock.add_response(
+def test_header(order, idempotency_key, respx_mock):
+    respx_mock.route(
         url=f"https://partner.dolyame.ru/v1/orders/{order.slug}/commit",
-        match_headers={
+        headers={
             "X-Correlation-ID": "SOME-OTHER-VALUE",
         },
-        json={},
-    )
+    ).respond(json={})
 
     tasks.commit_dolyame_order(order_id=order.id, idempotency_key=idempotency_key)

--- a/src/tinkoff/tests/dolyame_client/test_dolyame_refund.py
+++ b/src/tinkoff/tests/dolyame_client/test_dolyame_refund.py
@@ -2,6 +2,8 @@ import json
 import pytest
 import uuid
 
+from respx import MockRouter
+
 from tinkoff import tasks
 
 pytestmark = [pytest.mark.django_db]
@@ -12,7 +14,7 @@ def idempotency_key() -> str:
     return str(uuid.uuid4())
 
 
-def test(order, idempotency_key, respx_mock):
+def test(order, idempotency_key, respx_mock: MockRouter):
     respx_mock.route(
         url=f"https://partner.dolyame.ru/v1/orders/{order.slug}/refund",
         headers={
@@ -30,7 +32,7 @@ def test(order, idempotency_key, respx_mock):
 
 
 @pytest.mark.xfail(strict=True, reason="Just to make sure above code works")
-def test_header(order, idempotency_key, respx_mock):
+def test_header(order, idempotency_key, respx_mock: MockRouter):
     respx_mock.route(
         url=f"https://partner.dolyame.ru/v1/orders/{order.slug}/refund",
         headers={

--- a/src/tinkoff/tests/dolyame_client/test_dolyame_refund.py
+++ b/src/tinkoff/tests/dolyame_client/test_dolyame_refund.py
@@ -2,8 +2,6 @@ import json
 import pytest
 import uuid
 
-from pytest_httpx import HTTPXMock
-
 from tinkoff import tasks
 
 pytestmark = [pytest.mark.django_db]
@@ -14,17 +12,16 @@ def idempotency_key() -> str:
     return str(uuid.uuid4())
 
 
-def test(order, idempotency_key, httpx_mock: HTTPXMock):
-    httpx_mock.add_response(
+def test(order, idempotency_key, respx_mock):
+    respx_mock.route(
         url=f"https://partner.dolyame.ru/v1/orders/{order.slug}/refund",
-        match_headers={
+        headers={
             "X-Correlation-ID": idempotency_key,
         },
-        json={},
-    )
+    ).respond(json={})
 
     tasks.refund_dolyame_order(order_id=order.id, idempotency_key=idempotency_key)
-    result = json.loads(httpx_mock.get_requests()[0].content)
+    result = json.loads(respx_mock.calls.last.request.content)
 
     assert result["amount"] == "100500"
     assert result["returned_items"][0]["name"] == "Предоставление доступа к записи курса «Пентакли и Тентакли»"
@@ -33,13 +30,12 @@ def test(order, idempotency_key, httpx_mock: HTTPXMock):
 
 
 @pytest.mark.xfail(strict=True, reason="Just to make sure above code works")
-def test_header(order, idempotency_key, httpx_mock: HTTPXMock):
-    httpx_mock.add_response(
+def test_header(order, idempotency_key, respx_mock):
+    respx_mock.route(
         url=f"https://partner.dolyame.ru/v1/orders/{order.slug}/refund",
-        match_headers={
+        headers={
             "X-Correlation-ID": "SOME-OTHER-VALUE",
         },
-        json={},
-    )
+    ).respond(json={})
 
     tasks.refund_dolyame_order(order_id=order.id, idempotency_key=idempotency_key)

--- a/src/tinkoff/tests/dolyame_notifications/test_creating_dolyame_notifications.py
+++ b/src/tinkoff/tests/dolyame_notifications/test_creating_dolyame_notifications.py
@@ -33,11 +33,8 @@ def test_status(api, notification, status):
     assert notification.status == status
 
 
-def test_autocommit_is_sent(api, notification, order, httpx_mock):
-    httpx_mock.add_response(
-        url=f"https://partner.dolyame.ru/v1/orders/{order.slug}/commit",
-        json={},
-    )
+def test_autocommit_is_sent(api, notification, order, respx_mock):
+    respx_mock.post(url=f"https://partner.dolyame.ru/v1/orders/{order.slug}/commit").respond(json={})
 
     api.post("/api/v2/banking/dolyame-notifications/", notification(status="wait_for_commit"), expected_status_code=200)
 


### PR DESCRIPTION
Как обещал здесь https://github.com/tough-dev-school/education-backend/pull/1941#issuecomment-1708268337

Заменил везде httpx_mock на respx_mock и дропнул pytest-httpx из зависимостей