### PR TITLE
Set first_contact status for lead when update

### DIFF
--- a/src/amocrm/services/orders/order_pusher.py
+++ b/src/amocrm/services/orders/order_pusher.py
@@ -43,7 +43,7 @@ class AmoCRMOrderPusher(BaseService):
         else:
             if existing_lead.order != self.order:
                 self.relink_lead(order=self.order, lead=existing_lead)
-                AmoCRMLead(order=self.order).update()  # actualize lead's price and created_at
+                AmoCRMLead(order=self.order).update(status="first_contact")  # actualize lead's price, created_at and set lead to 'active' status
 
     def create_lead(self) -> None:
         lead_id = AmoCRMLead(order=self.order).create()

--- a/src/amocrm/services/orders/order_pusher.py
+++ b/src/amocrm/services/orders/order_pusher.py
@@ -43,7 +43,7 @@ class AmoCRMOrderPusher(BaseService):
         else:
             if existing_lead.order != self.order:
                 self.relink_lead(order=self.order, lead=existing_lead)
-                AmoCRMLead(order=self.order).update(status="first_contact")  # actualize lead's price, created_at and set lead to 'active' status
+                self.reactivate_lead_in_amocrm()
 
     def create_lead(self) -> None:
         lead_id = AmoCRMLead(order=self.order).create()
@@ -68,12 +68,17 @@ class AmoCRMOrderPusher(BaseService):
         if order_with_lead is not None:
             return order_with_lead.amocrm_lead
 
-    def relink_lead(self, order: Order, lead: AmoCRMOrderLead) -> None:
+    @staticmethod
+    def relink_lead(order: Order, lead: AmoCRMOrderLead) -> None:
         old_order = lead.order
         old_order.amocrm_lead = None
         old_order.save()
         order.amocrm_lead = lead
         order.save()
+
+    def reactivate_lead_in_amocrm(self) -> None:
+        """Actualize lead's price, created_at and set lead to 'active' status"""
+        AmoCRMLead(order=self.order).update(status="first_contact")
 
     def order_must_be_pushed(self) -> bool:
         if self.order.is_b2b:

--- a/src/amocrm/tests/services/order/tests_order_pusher.py
+++ b/src/amocrm/tests/services/order/tests_order_pusher.py
@@ -97,15 +97,22 @@ def test_created_transaction_is_linked(paid_order_with_lead):
 
 
 @pytest.mark.usefixtures("not_paid_order_with_lead")
-def test_relink_new_not_paid_order(not_paid_order_without_lead, mock_update_lead, amocrm_lead):
-    """
-    Поступил новый открытый заказ, но аналогичная сделка уже есть в Амо - привязываем сделку к текущему заказу и обновляем сделку в Амо,
-    устанавлияваем статус как "новое обращение", чтобы гарантированно вернуть сделку в "активное" состояние
-    """
+def test_order_is_relinked(not_paid_order_without_lead, mock_update_lead, amocrm_lead):
+    """Поступил новый открытый заказ, но аналогичная сделка уже есть в Амо - привязываем сделку к текущему заказу"""
     AmoCRMOrderPusher(order=not_paid_order_without_lead)()
 
     not_paid_order_without_lead.refresh_from_db()
     assert not_paid_order_without_lead.amocrm_lead == amocrm_lead
+
+
+@pytest.mark.usefixtures("not_paid_order_with_lead")
+def test_amocrm_lead_status_is_updated(not_paid_order_without_lead, mock_update_lead, amocrm_lead):
+    """
+    Поступил новый открытый заказ, но аналогичная сделка уже есть в Амо - привязываем сделку к текущему заказу и обновляем сделку в Амо,
+    устанавливаем статус как "новое обращение", чтобы гарантированно вернуть сделку в "активное" состояние
+    """
+    AmoCRMOrderPusher(order=not_paid_order_without_lead)()
+
     mock_update_lead.assert_called_once_with(status="first_contact")
 
 

--- a/src/amocrm/tests/services/order/tests_order_pusher.py
+++ b/src/amocrm/tests/services/order/tests_order_pusher.py
@@ -98,12 +98,15 @@ def test_created_transaction_is_linked(paid_order_with_lead):
 
 @pytest.mark.usefixtures("not_paid_order_with_lead")
 def test_relink_new_not_paid_order(not_paid_order_without_lead, mock_update_lead, amocrm_lead):
-    """Поступил новый открытый заказ, но аналогичная сделка уже есть в Амо - привязываем сделку к текущему заказу и обновляем сделку в Амо"""
+    """
+    Поступил новый открытый заказ, но аналогичная сделка уже есть в Амо - привязываем сделку к текущему заказу и обновляем сделку в Амо,
+    устанавлияваем статус как "новое обращение", чтобы гарантированно вернуть сделку в "активное" состояние
+    """
     AmoCRMOrderPusher(order=not_paid_order_without_lead)()
 
     not_paid_order_without_lead.refresh_from_db()
     assert not_paid_order_without_lead.amocrm_lead == amocrm_lead
-    mock_update_lead.assert_called_once()
+    mock_update_lead.assert_called_once_with(status="first_contact")
 
 
 @pytest.mark.usefixtures("not_paid_order_with_lead", "mock_create_transaction")


### PR DESCRIPTION
К [багу](https://3.basecamp.com/5104612/buckets/29069198/todos/6526358104)

При обновлении существующей сделки теперь будет передаваться статус "новое обращение", чтобы гарантировано возвращать её в активное состояние

Можно было бы завернуть это поведение в дефолтное для update, но так, кажется, более явно и понятно