### PR TITLE
Make AmoCRM cache works

### DIFF
--- a/src/amocrm/tests/http/test_cache_control.py
+++ b/src/amocrm/tests/http/test_cache_control.py
@@ -1,0 +1,36 @@
+import pytest
+
+import httpx
+
+from amocrm.client.http import AmoCRMCacheControl
+
+pytestmark = [
+    pytest.mark.freeze_time("2023-09-08 11:17:12-04:00"),
+]
+
+
+@pytest.fixture(scope="session")
+def httpx_request():
+    return httpx.Request("GET", "http://httpx-cache")
+
+
+def test_response_fresh_no_headers(httpx_request):
+    response = httpx.Response(200, content=b"httpx-cache-is-awesome")
+
+    assert AmoCRMCacheControl().is_response_fresh(request=httpx_request, response=response) is True
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {"expires": "Tue, 15 Nov 1994 12:45:26 GMT"},
+        {"date": "Fri, 8 Sep 2023 12:45:26 GMT", "expires": "lala"},
+        {"date": "Fri, 8 Sep 2023 12:45:26 GMT", "expires": "Tue, 15 Nov 1994 12:45:26 GMT"},
+        {"date": "Fri, 8 Sep 2023 12:45:26 GMT", "expires": "Tue, 15 Nov 1994 12:45:26 GMT", "cache-control": "max-age=900"},
+        {"date": "Fri, 8 Sep 2023 12:45:26 GMT", "expires": "Tue, 15 Nov 1994 12:45:26 GMT", "cache-control": "max-age=0"},
+    ],
+)
+def test_is_response_fresh_with_any_cache_related_headers(headers, httpx_request):
+    response = httpx.Response(200, headers=headers, content=b"httpx-cache-is-awesome")
+
+    assert AmoCRMCacheControl().is_response_fresh(request=httpx_request, response=response) is True


### PR DESCRIPTION
Увидел [в сентри](https://f213.sentry.io/issues/4463487968/events/427f7a50d7a34e96ad42bd66ae4d614a/?project=1807512), что по факту кеш для амо как-будто не работает. (по факту, ответы кешируются, но происходит мгновенная инвалидация)

Сделал решение, переопределив пару методов как [описано](https://obendidi.github.io/httpx-cache/cache_control/#use-your-own-cachecontroller) в доке библиотеки (там немного устаревший пример, судя по всему)

Описываю в чем была проблема. Что я не учел при предыдущих тестах. Что сделал, чтобы исправить:

- Амо присылает такие Responses, где в заголовках указано, что кеш по-умолчанию не доступен и сразу тухнет (а библиотека эта учитывает и когда достает Response из кеша сразу [считает его тухлым](https://github.com/obendidi/httpx-cache/blob/adbbeda5d5a357f88bde00de7c77ed135485aa21/httpx_cache/cache_control.py#L71) и посылает запрос заново)
- Я в тестах до этого про эти заголовки и не подумал, из-за чего пропустил это в прод.
- Сейчас переопределил метод проверки свежести ответа так, чтобы он всегда воспринимал его как актуальный. Дописал заголовки в тесте (скопировал как есть с реального ответа). Дописал тест "как было" и отметил xfail