### PR TITLE
remove update fields from testutilsmixin update method

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -17,9 +17,7 @@ class TestUtilsMixin:
         for key, value in kwargs.items():
             setattr(self, key, value)
 
-        update_fields = list(kwargs) + ["modified"] if hasattr(self, "modified") else list(kwargs)
-
-        self.save(update_fields=update_fields)
+        self.save()
 
         return self
 


### PR DESCRIPTION
Предлагаю убрать `update_fields=["` из `TestUtilsMixin.update(…`, т. к. он, кроме `midified`, не учитывает никаких других полей, которые тоже могут обновляться автоматически (и, соответственно, не сохраняет их). Например, поле `deleted` в [`StoreDeleted`](https://github.com/audiolion/django-behaviors?tab=readme-ov-file#storedeleted-behavior)-модели.

Без `update_fields=["` не так эффективно, зато на все случаи жизни.