### PR TITLE
Custom admin site for reordering app list

### DIFF
--- a/src/apps/orders/tests/orders/services/tests_order_refunder.py
+++ b/src/apps/orders/tests/orders/services/tests_order_refunder.py
@@ -21,11 +21,6 @@ pytestmark = [
 
 
 @pytest.fixture(autouse=True)
-def _set_locale(settings):
-    settings.LANGUAGE_CODE = "en"
-
-
-@pytest.fixture(autouse=True)
 def _adjust_settings(settings):
     settings.BANKS_REFUNDS_ENABLED = True
     settings.ABSOLUTE_HOST = "http://absolute-url.url"

--- a/src/apps/orders/tests/orders/services/tests_order_refunder.py
+++ b/src/apps/orders/tests/orders/services/tests_order_refunder.py
@@ -21,6 +21,11 @@ pytestmark = [
 
 
 @pytest.fixture(autouse=True)
+def _set_locale(settings):
+    settings.LANGUAGE_CODE = "en"
+
+
+@pytest.fixture(autouse=True)
 def _adjust_settings(settings):
     settings.BANKS_REFUNDS_ENABLED = True
     settings.ABSOLUTE_HOST = "http://absolute-url.url"

--- a/src/core/admin/admin_site.py
+++ b/src/core/admin/admin_site.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from django.contrib import admin
 from django.http.request import HttpRequest
 
@@ -14,7 +12,8 @@ class AdminSite(admin.AdminSite):
         app_list.sort(key=self._get_app_order_index)
         return app_list
 
-    def _get_app_order_index(self, element: Any) -> int:
+    @staticmethod
+    def _get_app_order_index(element: dict) -> int:
         app_order = ["orders", "notion", "chains", "products", "otherapp"]
 
         if element["app_label"] in app_order:

--- a/src/core/admin/admin_site.py
+++ b/src/core/admin/admin_site.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from django.contrib import admin
+from django.http.request import HttpRequest
 
 
 class AdminSite(admin.AdminSite):
@@ -8,11 +9,18 @@ class AdminSite(admin.AdminSite):
         super().__init__(name=name)
         self._registry.update(admin.site._registry)
 
-    def get_app_list(self, request: Any, app_label: Any | None = None) -> list[Any]:
+    def get_app_list(self, request: HttpRequest, app_label: str | None = None) -> list[str]:
         app_list = super().get_app_list(request, app_label)
-        app_order = ["orders", "notion", "chains", "products", "otherapp"]
-        app_list.sort(key=lambda x: app_order.index(x["app_label"]) if x["app_label"] in app_order else len(app_order))
+        app_list.sort(key=self._get_app_order_index)
         return app_list
+
+    def _get_app_order_index(self, element: Any) -> int:
+        app_order = ["orders", "notion", "chains", "products", "otherapp"]
+
+        if element["app_label"] in app_order:
+            return app_order.index(element["app_label"])
+
+        return len(app_order)
 
 
 admin_site = AdminSite(name="custom_admin")

--- a/src/core/admin/admin_site.py
+++ b/src/core/admin/admin_site.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+from django.contrib import admin
+
+class AdminSite(admin.AdminSite):
+
+    def __init__(self, *args, **kwargs):
+        super(AdminSite, self).__init__(*args, **kwargs)
+        self._registry.update(admin.site._registry)
+
+    def get_app_list(self, request: Any, app_label=None) -> list[Any]:
+        app_list = super().get_app_list(request, app_label)
+        app_order = ['orders', 'notion', 'chains', 'products', 'otherapp']
+        app_list.sort(key=lambda x: app_order.index(x['app_label']) if x['app_label'] in app_order else len(app_order))
+        return app_list
+    
+admin_site = AdminSite(name='custom_admin')

--- a/src/core/admin/admin_site.py
+++ b/src/core/admin/admin_site.py
@@ -9,7 +9,7 @@ class AdminSite(admin.AdminSite):
         super().__init__(name=name)
         self._registry.update(admin.site._registry)
 
-    def get_app_list(self, request: HttpRequest, app_label: str | None = None) -> list[str]:
+    def get_app_list(self, request: HttpRequest, app_label: str | None = None) -> list[dict]:
         app_list = super().get_app_list(request, app_label)
         app_list.sort(key=self._get_app_order_index)
         return app_list

--- a/src/core/admin/admin_site.py
+++ b/src/core/admin/admin_site.py
@@ -2,16 +2,17 @@ from typing import Any
 
 from django.contrib import admin
 
-class AdminSite(admin.AdminSite):
 
-    def __init__(self, *args, **kwargs):
-        super(AdminSite, self).__init__(*args, **kwargs)
+class AdminSite(admin.AdminSite):
+    def __init__(self, name: str) -> None:
+        super().__init__(name=name)
         self._registry.update(admin.site._registry)
 
-    def get_app_list(self, request: Any, app_label=None) -> list[Any]:
+    def get_app_list(self, request: Any, app_label: Any | None = None) -> list[Any]:
         app_list = super().get_app_list(request, app_label)
-        app_order = ['orders', 'notion', 'chains', 'products', 'otherapp']
-        app_list.sort(key=lambda x: app_order.index(x['app_label']) if x['app_label'] in app_order else len(app_order))
+        app_order = ["orders", "notion", "chains", "products", "otherapp"]
+        app_list.sort(key=lambda x: app_order.index(x["app_label"]) if x["app_label"] in app_order else len(app_order))
         return app_list
-    
-admin_site = AdminSite(name='custom_admin')
+
+
+admin_site = AdminSite(name="custom_admin")

--- a/src/core/urls/__init__.py
+++ b/src/core/urls/__init__.py
@@ -1,9 +1,9 @@
 import debug_toolbar  # type: ignore
 from django.conf.urls import include
-from django.contrib import admin
 from django.urls import path
 
 from core.views import HomePageView
+from core.admin.admin_site import admin_site
 
 api = [
     path("v2/", include("core.urls.v2")),
@@ -11,7 +11,7 @@ api = [
 
 urlpatterns = [
     path("api/", include(api)),
-    path("admin/", admin.site.urls),
+    path("admin/", admin_site.urls),
     path("__debug__/", include(debug_toolbar.urls)),
     path("", HomePageView.as_view()),
 ]

--- a/src/core/urls/__init__.py
+++ b/src/core/urls/__init__.py
@@ -2,8 +2,8 @@ import debug_toolbar  # type: ignore
 from django.conf.urls import include
 from django.urls import path
 
-from core.views import HomePageView
 from core.admin.admin_site import admin_site
+from core.views import HomePageView
 
 api = [
     path("v2/", include("core.urls.v2")),


### PR DESCRIPTION
:camping: https://3.basecamp.com/5104612/buckets/29069198/todos/7868529269

Добавил кастомный AdminSite, чтобы была возможность в нём сделать переопределение get_app_list и поменять сортировку для разделов и закинул его в urlpatterns вместо дефолтного, теперь в дашборде отсортировано как надо.

Сейчас если зайти в какую-нибудь модель, то в сайдбаре с аппками сортировка новая применяться не будет, я пока не могу понять, как подключить новый AdminSite для всего сразу, вообще мне хочется понять в том ли я направлению иду или какая-то другая реализация здесь нужна.

Есть ещё такой пакетик https://pypi.org/project/django-modeladmin-reorder/, но его втягивать побрезговал, хоть он вроде и рабочий до сих пор




