### PR TITLE
Set en locale for order refunder tests

### DIFF
--- a/src/apps/orders/tests/orders/services/tests_order_refunder.py
+++ b/src/apps/orders/tests/orders/services/tests_order_refunder.py
@@ -21,6 +21,11 @@ pytestmark = [
 
 
 @pytest.fixture(autouse=True)
+def _set_locale(settings):
+    settings.LANGUAGE_CODE = "en"
+
+
+@pytest.fixture(autouse=True)
 def _adjust_settings(settings):
     settings.BANKS_REFUNDS_ENABLED = True
     settings.ABSOLUTE_HOST = "http://absolute-url.url"


### PR DESCRIPTION
Добавил выставление английской локали для падающих у меня локально тестах
Инфа здесь: https://github.com/tough-dev-school/education-backend/pull/2421#issuecomment-2385563489