### PR TITLE
Исправление фильтрации ответов по курсам в админке

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,14 +71,14 @@ jobs:
 
       - name: Publish test results
         uses: phoenix-actions/test-reporting@v13
-        if: ${{ !contains(github.triggering_actor, '[bot]') }} && github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ !contains(github.triggering_actor, '[bot]') && github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           name: Test results
           path: "src/junit-*.xml"
           reporter: java-junit
 
       - name: Upload code coverage to codeclimate
-        if: ${{ github.ref == 'refs/heads/master' }} && github.repository_owner == 'tough-dev-school'
+        if: ${{ github.ref == 'refs/heads/master' && github.repository_owner == 'tough-dev-school' }}
         uses: paambaati/codeclimate-action@v8.0.0
         env:
           CC_TEST_REPORTER_ID: dd4cac59d43b52ee4c29cfed9d5162098a49ff65d9e72003abc1fa65cd608f1d

--- a/src/apps/homework/admin/answer/admin.py
+++ b/src/apps/homework/admin/answer/admin.py
@@ -14,7 +14,7 @@ class AnswerAdmin(ModelAdmin):
     list_filter = [
         IsRootFilter,
         "question",
-        "question__courses",
+        "study__course",
     ]
     list_display = [
         "created",
@@ -51,7 +51,7 @@ class AnswerAdmin(ModelAdmin):
     ]
 
     def get_queryset(self, request: Request) -> QuerySet:  # type: ignore
-        return super().get_queryset(request).with_crosscheck_count().select_related("author", "question", "study", "study__course", "study__course__group")  # type: ignore
+        return super().get_queryset(request).with_crosscheck_count().select_related("author", "question", "study__course__group")  # type: ignore
 
     @admin.display(description=_("Course"))
     def course(self, obj: Answer) -> str:
@@ -99,7 +99,9 @@ class AnswerCrossCheckAdmin(ModelAdmin):
             super()
             .get_queryset(request)
             .select_related(
-                "answer", "answer__question", "answer__question", "answer__author", "answer__study", "answer__study__course", "answer__study__course__group"
+                "answer__question",
+                "answer__author",
+                "answer__study__course__group",
             )
         )
 


### PR DESCRIPTION
Также были упрощены `select_related`, так как при использовании `relation1__relation2` `relation1` добавляется автоматически
Resolves #762 